### PR TITLE
Disable unneeded overriding mappings

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -11,7 +11,6 @@ local actions       = require('telescope.actions')
 local conf          = require('telescope.config').values
 local entry_display = require "telescope.pickers.entry_display"
 local finders       = require "telescope.finders"
-local mappings      = require('telescope.mappings')
 local path          = require('telescope.path')
 local pickers       = require "telescope.pickers"
 local sorters       = require "telescope.sorters"
@@ -227,13 +226,6 @@ local frecency = function(opts)
   if state.persistent_filter and state.last_filter then
     vim.fn.nvim_feedkeys(":" .. state.last_filter .. ":", "n", true)
   end
-
-  local restore_vim_maps = {}
-  restore_vim_maps.i = {
-    ['<C-x>'] = "<C-x>",
-    ['<C-u>'] = "<C-u>"
-  }
-  mappings.apply_keymap(state.picker.prompt_bufnr, mappings.attach_mappings, restore_vim_maps)
 
   vim.api.nvim_buf_set_option(state.picker.prompt_bufnr, "filetype", "frecency")
   vim.api.nvim_buf_set_option(state.picker.prompt_bufnr, "completefunc", "frecency#FrecencyComplete")


### PR DESCRIPTION
I re-mapped `<C-n>` in settings, but it is ignored with loading frecency. I noticed calling `apply_keymap()` causes this.

Without calling, it still seems to work all features including Workspace Filters. Is this needed?

```lua
    config = function()
      local telescope = require"telescope"
      local actions = require"telescope.actions"
      telescope.setup{
        defaults = {
          mappings = {
            i = {
              ["<C-j>"] = actions.move_selection_next,
              ["<C-k>"] = actions.move_selection_previous,
              ["<C-n>"] = actions.goto_file_selection_split,
            },
          },
        },
        extensions = {
          frecency = {
            workspaces = {
              vimrc = vim.env.HOME.."/.config/nvim",
            },
          },
        },
      }
      telescope.load_extension"frecency"
    end,
```

Full reproducible [Dockerfile][]

[Dockerfile]: https://gist.github.com/delphinus/50b959cc5301d843661ac6718cdc419d
