### PR TITLE
feat: allow user to disable database validation safe_mode

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -253,9 +253,10 @@ return telescope.register_extension {
     set_config_state('show_filter_column',  ext_config.show_filter_column, true)
     set_config_state('persistent_filter',   ext_config.persistent_filter, true)
     set_config_state('user_workspaces',     ext_config.workspaces, {})
+    set_config_state('db_safe_mode',        ext_config.db_safe_mode, true) -- require user confirmation by default
 
     -- start the database client
-    db_client.init(ext_config.ignore_patterns)
+    db_client.init(ext_config.ignore_patterns, state.db_safe_mode)
   end,
   exports = {
     frecency           = frecency,

--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -253,13 +253,13 @@ return telescope.register_extension {
     set_config_state('show_filter_column',  ext_config.show_filter_column, true)
     set_config_state('persistent_filter',   ext_config.persistent_filter, true)
     set_config_state('user_workspaces',     ext_config.workspaces, {})
-    set_config_state('db_safe_mode',        ext_config.db_safe_mode, true) -- require user confirmation by default
 
     -- start the database client
-    db_client.init(ext_config.ignore_patterns, state.db_safe_mode)
+    db_client.init(ext_config.ignore_patterns, ext_config.db_safe_mode or true, ext_config.auto_validate or true)
   end,
   exports = {
     frecency           = frecency,
     get_workspace_tags = get_workspace_tags,
+    validate_db        = db_client.validate,
   },
 }

--- a/lua/telescope/_extensions/frecency/db_client.lua
+++ b/lua/telescope/_extensions/frecency/db_client.lua
@@ -61,14 +61,15 @@ local function validate_db(safe_mode)
     confirmed = true
   elseif #pending_remove > DB_REMOVE_SAFETY_THRESHOLD then
      -- don't allow removal of >N values from DB without confirmation
-    if vim.fn.confirm("Telescope-Frecency: remove " .. #pending_remove .. " entries from SQLite3 database?", "&Yes\n&No", 2) then
+    local user_response = vim.fn.confirm("Telescope-Frecency: remove " .. #pending_remove .. " entries from SQLite3 database?", "&Yes\n&No", 2)
+    if user_response == 1 then
       confirmed = true
     else
-      print("TelescopeFrecency: validation aborted.")
+      vim.defer_fn(function() print("TelescopeFrecency: validation aborted.") end, 50)
     end
   end
 
-  if confirmed then
+  if confirmed == true then
     for _, entry in pairs(pending_remove) do
       -- remove entries from file and timestamp tables
       sql_wrapper:do_transaction(queries.file_delete_entry , {where = {id = entry.id }})

--- a/lua/telescope/_extensions/frecency/db_client.lua
+++ b/lua/telescope/_extensions/frecency/db_client.lua
@@ -56,17 +56,16 @@ local function validate_db(safe_mode)
     end
   end
 
-   -- don't allow removal of >N values from DB without confirmation (if safe mode is enabled)
-  local confirmed
-  if safe_mode then
-    confirmed = false
-    if #pending_remove > DB_REMOVE_SAFETY_THRESHOLD then
-      if vim.fn.confirm("Telescope-Frecency: remove " .. #pending_remove .. " entries from SQLite3 database?", "&Yes\n&No", 2) then
-        confirmed = true
-      end
-    end
-  else
+  local confirmed = false
+  if not safe_mode then
     confirmed = true
+  elseif #pending_remove > DB_REMOVE_SAFETY_THRESHOLD then
+     -- don't allow removal of >N values from DB without confirmation
+    if vim.fn.confirm("Telescope-Frecency: remove " .. #pending_remove .. " entries from SQLite3 database?", "&Yes\n&No", 2) then
+      confirmed = true
+    else
+      print("TelescopeFrecency: validation aborted.")
+    end
   end
 
   if confirmed then
@@ -75,8 +74,6 @@ local function validate_db(safe_mode)
       sql_wrapper:do_transaction(queries.file_delete_entry , {where = {id = entry.id }})
       sql_wrapper:do_transaction(queries.timestamp_delete_entry, {where = {file_id = entry.id}})
     end
-  else
-    print("TelescopeFrecency: validation aborted.")
   end
 end
 

--- a/plugin/frecency.vim
+++ b/plugin/frecency.vim
@@ -30,7 +30,4 @@ function! frecency#FrecencyComplete(findstart, base)
   end
 endfunction
 
-
-  " lua require'telescope'.extensions.frecency.completefunc(action)
-  " lua require'telescope'.extensions.frecency.completefunc(res)
-  " require'telescope._extensions.frecency.db_client'.autocmd_handler(vim.fn.expand('<amatch>'))
+command FrecencyValidate lua require'telescope'.extensions.frecency.validate_db()


### PR DESCRIPTION
set the config option `opts.db_safe_mode = false` to disable the prompt when the db validation function is going to remove more than <safety threshold>(10) entries at once.