### PR TITLE
Fix a typo in the Packer install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ use {
   "nvim-telescope/telescope-frecency.nvim",
   config = function()
     require"telescope".load_extension("frecency")
-    requires = {"tami5/sql.nvim"}
   end
+  requires = {"tami5/sql.nvim"}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use {
   "nvim-telescope/telescope-frecency.nvim",
   config = function()
     require"telescope".load_extension("frecency")
-  end
+  end,
   requires = {"tami5/sql.nvim"}
 }
 ```


### PR DESCRIPTION
I think this is a typo