### PR TITLE
Add default_workspace setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ See [default configuration](https://github.com/nvim-telescope/telescope.nvim#tel
   Path to parent directory of custom database location.
   Defaults to `$XDG_DATA_HOME/nvim` if unset.
 
+- `default_workspace` (default: `nil`)
+
+  Default workspace tag to filter by e.g. `'CWD'` to filter by default to the current directory. Can be overridden at query time by specifying another filter like `':*:'`.
+
 - `ignore_patterns` (default: `{"*.git/*", "*/tmp/*"}`)
 
   Patterns in this table control which files are indexed (and subsequently which you'll see in the finder results).

--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -29,6 +29,7 @@ local state = {
   previous_buffer = nil,
   cwd = nil,
   show_scores = false,
+  default_workspace = nil,
   user_workspaces = {},
   lsp_workspaces = {},
   picker = {},
@@ -189,6 +190,7 @@ local frecency = function(opts)
       if matched then
         query_text = query_text:sub(matched:len() + 1)
       end
+      new_filter = new_filter or state.default_workspace
 
       local new_finder
       local results_updated = update_results(new_filter)
@@ -274,6 +276,7 @@ return telescope.register_extension {
     set_config_state("show_filter_column", ext_config.show_filter_column, true)
     set_config_state("user_workspaces", ext_config.workspaces, {})
     set_config_state("disable_devicons", ext_config.disable_devicons, false)
+    set_config_state("default_workspace", ext_config.default_workspace, nil)
 
     -- start the database client
     db_client.init(


### PR DESCRIPTION
Add a `default_workspace` setting which if set to something other than nil, is used by default.

Re #39, I can get the picker to scope to the current working directory only by using a Telescope setting like the following
 
```lua
extensions = {
	frecency = {
		default_workspace = 'CWD',
	},
}
````

Then to scope back to everything I put a non-existent workspace tag in my query like `:*:` or `:blah:` (not sure if this is intentional or not)

If this setting could be useful I can add some documentation