### PR TITLE
Use telescope builtin transform_path

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -49,13 +49,7 @@ local function format_filepath(filename, opts)
     end
   end
 
-  if opts.tail_path then
-    filename = utils.path_tail(filename)
-  elseif opts.shorten_path then
-    filename = utils.path_shorten(filename)
-  end
-
-  return filename
+  return utils.transform_path(opts, filename)
 end
 
 local function get_workspace_tags()


### PR DESCRIPTION
Telescope has changed the way how the options for path transform can be set
https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/utils.lua#L338
Use the appropriate new interface to transform the paths for display.