### PR TITLE
fix: fetch lsp workspaces without triggering tag completion

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -53,6 +53,21 @@ local function format_filepath(filename, opts)
   return utils.transform_path(opts, filename)
 end
 
+local function fetch_lsp_workspaces(bufnr, force)
+  if not vim.tbl_isempty(state.lsp_workspaces) and not force then
+    return state.lsp_workspaces
+  end
+
+  local lsp_workspaces = vim.api.nvim_buf_call(bufnr, vim.lsp.buf.list_workspace_folders)
+  if not vim.tbl_isempty(lsp_workspaces) then
+    state.lsp_workspaces = lsp_workspaces
+  else
+    state.lsp_workspaces = {}
+  end
+
+  return state.lsp_workspaces
+end
+
 local function get_workspace_tags()
   -- Add user config workspaces. TODO: validate that workspaces are existing directories
   local tags = {}
@@ -64,12 +79,8 @@ local function get_workspace_tags()
   table.insert(tags, "CWD")
 
   -- Add LSP workpace(s)
-  local lsp_workspaces = vim.api.nvim_buf_call(state.previous_buffer, vim.lsp.buf.list_workspace_folders)
-  if not vim.tbl_isempty(lsp_workspaces) then
-    state.lsp_workspaces = lsp_workspaces
+  if not vim.tbl_isempty(fetch_lsp_workspaces(state.previous_buffer, true)) then
     table.insert(tags, "LSP")
-  else
-    state.lsp_workspaces = {}
   end
 
   -- print(vim.inspect(tags))
@@ -288,6 +299,15 @@ return telescope.register_extension {
       vim.F.if_nil(ext_config.db_safe_mode, true),
       vim.F.if_nil(ext_config.auto_validate, true)
     )
+
+    vim.api.nvim_create_autocmd("LspAttach", {
+      callback = function(args)
+        if not vim.tbl_isempty(fetch_lsp_workspaces(args.buf)) then
+          -- lsp workspaces found, remove the autocmd
+          return true
+        end
+      end,
+    })
   end,
   exports = {
     frecency = frecency,


### PR DESCRIPTION
Currently LSP workspaces are only fetched when user triggers `:<Tab>` completion. So, if you set your `default_workspace` to `LSP`, it doesn't work.

With the changes of this PR, LSP workspaces will be fetched as soon as LSP is attached to a buffer, so it'll work after that.