### PR TITLE
feat: use sorter fuzzy_with_index_bias

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -250,7 +250,7 @@ local frecency = function(opts)
       entry_maker = entry_maker,
     },
     previewer = conf.file_previewer(opts),
-    sorter = sorters.get_substr_matcher(opts),
+    sorter = sorters.fuzzy_with_index_bias(opts),
   })
   state.picker:find()
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8050659/184633937-a42448b4-3d5e-4371-be72-6d1c968a7a4e.png)

**Before**

Matches space separated queries, but hides everything else:

![image](https://user-images.githubusercontent.com/8050659/184649516-7ca488e8-f245-42ef-9644-84b4feed4677.png)

Can not fuzzy search:

![image](https://user-images.githubusercontent.com/8050659/184634010-083d1399-67d5-4555-a914-5e230c2b6353.png)


**After**

Supports fuzzy search and biased towards frecency order.

![image](https://user-images.githubusercontent.com/8050659/184649249-99a0cb03-4656-4042-800c-8a41f0efe597.png)