### PR TITLE
Use vim.notify not to block outputs

### DIFF
--- a/lua/telescope/_extensions/frecency/db_client.lua
+++ b/lua/telescope/_extensions/frecency/db_client.lua
@@ -27,7 +27,7 @@ local function import_oldfiles()
   for _, filepath in pairs(oldfiles) do
     sql_wrapper:update(filepath)
   end
-  print(("Telescope-Frecency: Imported %d entries from oldfiles."):format(#oldfiles))
+  vim.notify(("Telescope-Frecency: Imported %d entries from oldfiles."):format(#oldfiles))
 end
 
 local function file_is_ignored(filepath)
@@ -65,7 +65,7 @@ local function validate_db(safe_mode)
     if user_response == 1 then
       confirmed = true
     else
-      vim.defer_fn(function() print("TelescopeFrecency: validation aborted.") end, 50)
+      vim.defer_fn(function() vim.notify("TelescopeFrecency: validation aborted.") end, 50)
     end
   else
     confirmed = true
@@ -78,9 +78,9 @@ local function validate_db(safe_mode)
         sql_wrapper:do_transaction(queries.file_delete_entry , {where = {id = entry.id }})
         sql_wrapper:do_transaction(queries.timestamp_delete_entry, {where = {file_id = entry.id}})
       end
-      print(('Telescope-Frecency: removed %d missing entries.'):format(#pending_remove))
+      vim.notify(('Telescope-Frecency: removed %d missing entries.'):format(#pending_remove))
     else
-      print("Telescope-Frecency: validation aborted.")
+      vim.notify("Telescope-Frecency: validation aborted.")
     end
   end
 end

--- a/lua/telescope/_extensions/frecency/sql_wrapper.lua
+++ b/lua/telescope/_extensions/frecency/sql_wrapper.lua
@@ -45,7 +45,7 @@ function M:bootstrap(db_root)
   local db_filename = db_root .. "/file_frecency.sqlite3"
   self.db = sqlite:open(db_filename)
   if not self.db then
-    print("error")
+    vim.notify("Telescope-Frecency: error in opening DB", vim.log.levels.ERROR)
     return
   end
 


### PR DESCRIPTION
`print()` causes [hit-enter][] prompts when we are using `set cmdheight=0` in the latest Neovim.

```
Telescope-Frecency: Imported 2 entries from oldfiles.
Press ENTER or type command to continue  
```

[hit-enter]: https://neovim.io/doc/user/message.html#hit-enter

Neovim has [vim.notify][] for such cases. We can overwrite it with other plugins, such as [rcarriga/nvim-notify][], so that Neovim does not show the prompt and not block outputs.

[vim.notify]: https://neovim.io/doc/user/lua.html#vim.notify()
[rcarriga/nvim-notify]: https://github.com/rcarriga/nvim-notify