### PR TITLE
Detect entries when it has added new ones

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -199,7 +199,7 @@ local frecency = function(opts)
       state.active_filter_tag = filter
     end
 
-    if vim.tbl_isempty(state.results) or filter_updated then
+    if vim.tbl_isempty(state.results) or db_client.has_updated_results() or filter_updated then
       state.results = db_client.get_file_scores(state.show_unindexed, ws_dir)
     end
     return filter_updated

--- a/lua/telescope/_extensions/frecency/db_client.lua
+++ b/lua/telescope/_extensions/frecency/db_client.lua
@@ -182,6 +182,8 @@ local function filter_workspace(workspace_path, show_unindexed)
   return res
 end
 
+local updated = false
+
 local function get_file_scores(show_unindexed, workspace_path)
   if not sql_wrapper then return {} end
 
@@ -205,6 +207,8 @@ local function get_file_scores(show_unindexed, workspace_path)
   -- sort the table
   table.sort(scores, function(a, b) return a.score > b.score end)
 
+  updated = false
+
   return scores
 end
 
@@ -218,8 +222,12 @@ local function autocmd_handler(filepath)
     if file_is_ignored(filepath) then return end
 
     vim.b.telescope_frecency_registered = 1
-    sql_wrapper:update(filepath)
+    updated = sql_wrapper:update(filepath)
   end
+end
+
+local function has_updated_results()
+  return updated
 end
 
 return {
@@ -227,4 +235,5 @@ return {
   get_file_scores = get_file_scores,
   autocmd_handler = autocmd_handler,
   validate        = validate_db,
+  has_updated_results = has_updated_results,
 }

--- a/lua/telescope/_extensions/frecency/sql_wrapper.lua
+++ b/lua/telescope/_extensions/frecency/sql_wrapper.lua
@@ -154,9 +154,11 @@ function M:update(filepath)
   -- create entry if it doesn't exist
   local file_id
   file_id = row_id(self:do_transaction(queries.file_get_entries, {where = {path = filepath}}))
+  local has_added_entry
   if not file_id then
     self:do_transaction(queries.file_add_entry, {path = filepath, count = 1})
     file_id = row_id(self:do_transaction(queries.file_get_entries, {where = {path = filepath}}))
+    has_added_entry = true
   else
   -- ..or update existing entry
     self:do_transaction(queries.file_update_counter, {path = filepath})
@@ -171,6 +173,8 @@ function M:update(filepath)
   if trim_at then
     self:do_transaction(queries.timestamp_delete_before_id, {id = trim_at.id, file_id = file_id})
   end
+
+  return has_added_entry
 end
 
 return M


### PR DESCRIPTION
I found it does not show newly created files in results until I restart Neovim. This is because `db_client.get_file_scores()` is called only once if the filter is not updated.

### reproducible process

1. Launch Neovim.
2. `:e ~/foo.txt`
3. Launch telescope-frecency:
   - And we cannot see `~/foo.txt` in results.

This patch changes the logic to call `get_file_scores()` again when an entry is added to the table in autocmd events, especially `BufWritePost`.