### PR TITLE
fix: use substr matcher to use sorting by scores

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -276,7 +276,7 @@ local frecency = function(opts)
       entry_maker = entry_maker,
     },
     previewer = require("telescope.config").values.file_previewer(opts),
-    sorter = require'telescope.sorters'.fuzzy_with_index_bias(opts),
+    sorter = require'telescope.sorters'.get_substr_matcher(opts),
   })
   state.picker:find()
 


### PR DESCRIPTION
#73 has introduced fuzzy matcher but it breaks score-based sorting. This fixes it.

1. Open telescope-frecency
   <img width="673" alt="スクリーンショット 0005-04-10 14 49 29@2x" src="https://user-images.githubusercontent.com/1239245/230838274-f2e6c980-6d66-4d89-bd04-042ef230164c.png">
2. With `fuzzy_with_index_bias`, it breaks sorting.
   <img width="671" alt="スクリーンショット 0005-04-10 14 49 51@2x" src="https://user-images.githubusercontent.com/1239245/230838462-51413e88-e682-4c32-aa61-06e431a20d10.png">
3. With `get_substr_matcher`,
   <img width="671" alt="スクリーンショット 0005-04-10 14 56 18" src="https://user-images.githubusercontent.com/1239245/230838574-ed69e2f1-7b30-4107-8c88-158f388684ec.png">
 it does not.
   

