### PR TITLE
Revert "fix: set prompt filetype to `TelescopePrompt` (#81)"

### DIFF
--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -280,7 +280,7 @@ local frecency = function(opts)
   })
   state.picker:find()
 
-  vim.api.nvim_buf_set_option(state.picker.prompt_bufnr, "filetype", "TelescopePrompt")
+  vim.api.nvim_buf_set_option(state.picker.prompt_bufnr, "filetype", "frecency")
   vim.api.nvim_buf_set_option(state.picker.prompt_bufnr, "completefunc", "frecency#FrecencyComplete")
   vim.api.nvim_buf_set_keymap(
     state.picker.prompt_bufnr,


### PR DESCRIPTION
This reverts commit e8e97eeebdfc2e678f88fdf2ddf9cf2c82b16030.

This plugin defines the filetype `frecency` to use a customized syntax to highlight tags in input characters. So we should use `frecency` here.

<img width="141" alt="スクリーンショット 0005-04-11 10 09 02" src="https://user-images.githubusercontent.com/1239245/231029307-e09ede61-a0ee-49fe-8fa5-25654a193ca5.png">