### PR TITLE
chore: add types for plenary.async

### DIFF
--- a/lua/frecency/async_finder.lua
+++ b/lua/frecency/async_finder.lua
@@ -1,17 +1,11 @@
-local async = require "plenary.async"
+local async = require "plenary.async" --[[@as PlenaryAsync]]
 
 ---@class FrecencyAsyncFinder
 ---@field closed boolean
 ---@field entries FrecencyEntry[]
----@field rx FrecencyRx
+---@field rx PlenaryAsyncControlChannelRx
 ---@overload fun(_: string, process_result: (fun(entry: FrecencyEntry): nil), process_complete: fun(): nil): nil
 local AsyncFinder = {}
-
----@class FrecencyRx
----@field recv fun(): FrecencyEntry?
-
----@class FrecencyTx
----@field send fun(entry: FrecencyEntry?): nil
 
 ---@param fs FrecencyFS
 ---@param path string
@@ -33,7 +27,6 @@ AsyncFinder.new = function(fs, path, entry_maker, initial_results)
     entry.index = i
     table.insert(self.entries, entry)
   end
-  ---@type FrecencyTx, FrecencyRx
   local tx, rx = async.control.channel.mpsc()
   self.rx = rx
   async.run(function()

--- a/lua/frecency/types.lua
+++ b/lua/frecency/types.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: unused-local
 -- NOTE: types below are borrowed from sqlite.lua
 
 ---@class sqlite_db @Main sqlite.lua object.
@@ -64,6 +65,41 @@
 ---@field silent boolean              if true will not echo messages that are not accessible
 
 ---@alias scan_dir fun(path: string, opts: PlenaryScanDirOptions): string[]
+
+---@class PlenaryAsync
+---@field control PlenaryAsyncControl
+---@field util PlenaryAsyncUtil
+local PlenaryAsync = {}
+
+---@async
+---@param f fun(): nil
+---@return nil
+function PlenaryAsync.run(f) end
+
+---@class PlenaryAsyncControl
+---@field channel PlenaryAsyncControlChannel
+
+---@class PlenaryAsyncControlChannel
+---@field mpsc fun(): PlenaryAsyncControlChannelTx, PlenaryAsyncControlChannelRx
+
+---@class PlenaryAsyncControlChannelTx
+---@field send fun(entry: FrecencyEntry?): nil
+local PlenaryAsyncControlChannelTx = {}
+
+---@class PlenaryAsyncControlChannelRx
+local PlenaryAsyncControlChannelRx = {}
+
+---@async
+---@return FrecencyEntry?
+function PlenaryAsyncControlChannelRx.recv() end
+
+---@class PlenaryAsyncUtil
+local PlenaryAsyncUtil = {}
+
+---@async
+---@param ms integer
+---@return nil
+function PlenaryAsyncUtil.sleep(ms) end
 
 -- NOTE: types are for telescope.nvim
 


### PR DESCRIPTION
Add typings for async functions in `plenary.async`.