### PR TITLE
refactor: remove logic for caching feature

### DIFF
--- a/lua/frecency/frecency.lua
+++ b/lua/frecency/frecency.lua
@@ -5,6 +5,7 @@ local Finder = require "frecency.finder"
 local Picker = require "frecency.picker"
 local Recency = require "frecency.recency"
 local WebDevicons = require "frecency.web_devicons"
+local log = require "plenary.log"
 
 ---@class Frecency
 ---@field config FrecencyConfig
@@ -92,6 +93,8 @@ end
 ---@param opts FrecencyPickerOptions?
 ---@return nil
 function Frecency:start(opts)
+  local start = os.clock()
+  log.debug "Frecency:start"
   opts = opts or {}
   self.picker = Picker.new(self.database, self.finder, self.fs, self.recency, {
     default_workspace_tag = self.config.default_workspace,
@@ -102,6 +105,7 @@ function Frecency:start(opts)
     workspaces = self.config.workspaces,
   })
   self.picker:start(opts)
+  log.debug(("Frecency:start picker:start takes %f seconds"):format(os.clock() - start))
 end
 
 ---@param findstart 1|0

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -76,13 +76,9 @@ function Picker:start(opts)
       return self:default_path_display(picker_opts, path)
     end,
   }, opts or {}) --[[@as FrecencyPickerOptions]]
-  self.lsp_workspaces = {}
-  local workspace = self:get_workspace(opts.cwd, self.config.initial_workspace_tag)
-  log.debug { workspace = workspace, ["self.workspace"] = self.workspace }
-  if vim.tbl_isempty(self.results) or workspace ~= self.workspace then
-    self.workspace = workspace
-    self.results = self:fetch_results(self.workspace)
-  end
+  self.workspace = self:get_workspace(opts.cwd, self.config.initial_workspace_tag)
+  log.debug { workspace = self.workspace }
+  self.results = self:fetch_results(self.workspace)
 
   local state = State.new()
 
@@ -109,7 +105,7 @@ function Picker:start(opts)
 end
 
 function Picker:discard_results()
-  self.results = {}
+  -- TODO: implement here when it needs to cache.
 end
 
 --- See :h 'complete-functions'


### PR DESCRIPTION
The current logic can get candidates sufficiently fast. Remove logic for caching feature that still remained.

----

NOTE: My box has a DB containing 1284 files and 2973 timestamps. `:Telescope frecency` takes around 20 milliseconds on average.