### PR TITLE
feat: `hide_current_buffer` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ See [default configuration](https://github.com/nvim-telescope/telescope.nvim#tel
 
   Disable devicons (if available)
 
+- `hide_current_buffer` (default: `false`)
+
+  If `true`, it does not show the current buffer in candidates.
+
 - `filter_delimiter` (default: `":"`)
 
   Delimiters to indicate the filter like `:CWD:`.

--- a/lua/frecency/frecency.lua
+++ b/lua/frecency/frecency.lua
@@ -25,6 +25,7 @@ local Frecency = {}
 ---@field default_workspace string? default: nil
 ---@field disable_devicons boolean? default: false
 ---@field filter_delimiter string? default: ":"
+---@field hide_current_buffer boolean default: false
 ---@field ignore_patterns string[]? default: { "*.git/*", "*/tmp/*", "term://*" }
 ---@field max_timestamps integer? default: 10
 ---@field show_filter_column boolean|string[]|nil default: true
@@ -45,6 +46,7 @@ Frecency.new = function(opts)
     default_workspace = nil,
     disable_devicons = false,
     filter_delimiter = ":",
+    hide_current_buffer = false,
     ignore_patterns = os_util.is_windows and { [[*.git\*]], [[*\tmp\*]], "term://*" }
       or { "*.git/*", "*/tmp/*", "term://*" },
     max_timestamps = 10,
@@ -113,10 +115,15 @@ function Frecency:start(opts)
   if opts.cwd then
     opts.cwd = vim.fn.expand(opts.cwd)
   end
+  local ignore_filenames
+  if opts.hide_current_buffer or self.config.hide_current_buffer then
+    ignore_filenames = { vim.api.nvim_buf_get_name(0) }
+  end
   self.picker = Picker.new(self.database, self.entry_maker, self.fs, self.recency, {
     default_workspace_tag = self.config.default_workspace,
     editing_bufnr = vim.api.nvim_get_current_buf(),
     filter_delimiter = self.config.filter_delimiter,
+    ignore_filenames = ignore_filenames,
     initial_workspace_tag = opts.workspace,
     show_unindexed = self.config.show_unindexed,
     workspace_scan_cmd = self.config.workspace_scan_cmd,

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -26,6 +26,7 @@ local Picker = {}
 ---@field default_workspace_tag string?
 ---@field editing_bufnr integer
 ---@field filter_delimiter string
+---@field ignore_filenames string[]?
 ---@field initial_workspace_tag string?
 ---@field show_unindexed boolean
 ---@field workspace_scan_cmd "LUA"|string[]|nil
@@ -61,6 +62,7 @@ end
 
 ---@class FrecencyPickerOptions
 ---@field cwd string
+---@field hide_current_buffer boolean?
 ---@field path_display
 ---| "hidden"
 ---| "tail"
@@ -86,7 +88,7 @@ function Picker:finder(opts, workspace, workspace_tag)
     workspace,
     self.recency,
     self.state,
-    { workspace_scan_cmd = self.config.workspace_scan_cmd }
+    { ignore_filenames = self.config.ignore_filenames, workspace_scan_cmd = self.config.workspace_scan_cmd }
   )
 end
 


### PR DESCRIPTION
Fix #175 

With the new option:`hide_current_buffer`, frecency does not show the buffer the cursor was on when `:Telescope frecency` is called.

```lua
-- Set this in startup
telescope.setup {
  extensions = {
    frecency = {
      hide_current_buffer = true,
    },
  },
}
```

```vim
-- Overwrite config setting
:Telescope frecency hide_current_buffer=true
```