### PR TITLE
fix: respect telescope's `path_display`

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,33 @@ See [default configuration](https://github.com/nvim-telescope/telescope.nvim#tel
   timestamps when you open the file. It is reasonable to set this value more
   than or equal to the default value: `10`.
 
+- `path_display` (default: `nil`)
+
+  Overwrite the `path_display` setting in telescope.nvim itself. See
+  `:h telescope.defaults.path_display` for acceptable values. This setting will
+  be used by these priorities below.
+
+  1. Option specified with the command or Lua code.
+    - `:Telescope frecency path_display={"absolute"}`.
+    - or `:lua require("telescope").extensions.frecency.frecency { path_display = { "absolute" } }`.
+  2. `opts.extensions.frecency.path_display` in setup.
+  3. `opts.defaults.path_display` in setup.
+
+     ```lua
+     require("telescope").setup {
+       defaults = {
+         -- This has the 3rd precedence.
+         path_display = { "absolute" },
+       },
+       extensions = {
+         frecency = {
+           -- This has the 2nd precedence.
+           path_display = { "shorten" },
+         },
+       },
+     }
+     ```
+
 - `recency_values` (default: see below)
 
   Set weighting factors for calculating “frecency”. This option does not affect

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -18,6 +18,7 @@ local Config = {}
 ---@field matcher "default"|"fuzzy" default: "default"
 ---@field scoring_function fun(recency: integer, fzy_score: number): number default: see lua/frecency/config.lua
 ---@field max_timestamps integer default: 10
+---@field path_display? table default: nil
 ---@field show_filter_column boolean|string[] default: true
 ---@field show_scores boolean default: false
 ---@field show_unindexed boolean default: true
@@ -75,6 +76,7 @@ Config.new = function()
     ignore_patterns = true,
     matcher = true,
     max_timestamps = true,
+    path_display = true,
     scoring_function = true,
     show_filter_column = true,
     show_scores = true,

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -96,7 +96,7 @@ function Picker:start(opts)
     path_display = function(picker_opts, path)
       return self:default_path_display(picker_opts, path)
     end,
-  }, opts or {}) --[[@as FrecencyPickerOptions]]
+  }, config_values, opts or {}) --[[@as FrecencyPickerOptions]]
   self.workspace = self:get_workspace(opts.cwd, self.config.initial_workspace_tag or config.default_workspace)
   log.debug { workspace = self.workspace }
 
@@ -272,11 +272,6 @@ function Picker:filepath_formatter(picker_opts)
     opts.cwd = workspace or self.fs.os_homedir
 
     return function(filename)
-      local path_display = config_values.path_display
-      if type(path_display) == "table" and path_display.filename_first then
-        opts.path_display = path_display
-      end
-
       return utils.transform_path(opts, filename)
     end
   end


### PR DESCRIPTION
fix #47 

Now `path_display` can be specified by these priorities.

  1. Option specified with the command or Lua code.
    - `:Telescope frecency path_display={"absolute"}`.
    - or `:lua require("telescope").extensions.frecency.frecency { path_display = { "absolute" } }`.
  2. `opts.extensions.frecency.path_display` in setup.
  3. `opts.defaults.path_display` in setup.

     ```lua
     require("telescope").setup {
       defaults = {
         -- This has the 3rd precedence.
         path_display = { "absolute" },
       },
       extensions = {
         frecency = {
           -- This has the 2nd precedence.
           path_display = { "shorten" },
         },
       },
     }
     ```