### PR TITLE
feat!: set the default DB path to XDG_STATE_HOME

### DIFF
--- a/doc/telescope-frecency.txt
+++ b/doc/telescope-frecency.txt
@@ -241,11 +241,17 @@ If `true`, it removes stale entries count over than
 				      *telescope-frecency-configuration-db_root*
 db_root ~
 
-Default: `vim.fn.stdpath "data"`
+Default: `vim.fn.stdpath "state"`
 Type: `string`
 
 Path to the parent directory of custom database location. Defaults to
-`$XDG_DATA_HOME/nvim` if unset.
+|$XDG_STATE_HOME|/nvim (see |stdpath()|) if unset.
+
+NOTE: The default value was `vim.fn.stdpath "data"`. If you doesn't set this
+option and you have DB in `vim.fn.stdpath "data"` instead of
+`vim.fn.stdpath "state"`, it uses the one in the old path for backward
+compatibility. See the detail in the issue below.
+https://github.com/nvim-telescope/telescope-frecency.nvim/issues/200
 
 				 *telescope-frecency-configuration-db_safe_mode*
 db_safe_mode ~

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -1,6 +1,7 @@
 local os_util = require "frecency.os_util"
 
 ---@class FrecencyConfig: FrecencyRawConfig
+---@field ext_config FrecencyRawConfig
 ---@field private values FrecencyRawConfig
 local Config = {}
 
@@ -85,6 +86,7 @@ Config.new = function()
     workspaces = true,
   }
   return setmetatable({
+    ext_config = {},
     values = default_values,
   }, {
     __index = function(self, key)
@@ -140,6 +142,7 @@ Config.setup = function(ext_config)
     workspace_scan_cmd = { opts.workspace_scan_cmd, { "s", "t" }, true },
     workspaces = { opts.workspaces, "t" },
   }
+  config.ext_config = ext_config
   config.values = opts
 end
 

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -8,7 +8,7 @@ local Config = {}
 ---@class FrecencyRawConfig
 ---@field recency_values { age: integer, value: integer }[] default: see lua/frecency/config.lua
 ---@field auto_validate boolean default: true
----@field db_root string default: vim.fn.stdpath "data"
+---@field db_root string default: vim.fn.stdpath "state"
 ---@field db_safe_mode boolean default: true
 ---@field db_validate_threshold integer default: 10
 ---@field default_workspace? string default: nil
@@ -30,7 +30,7 @@ local Config = {}
 Config.new = function()
   local default_values = {
     auto_validate = true,
-    db_root = vim.fn.stdpath "data",
+    db_root = vim.fn.stdpath "state",
     db_safe_mode = true,
     db_validate_threshold = 10,
     default_workspace = nil,

--- a/lua/frecency/types.lua
+++ b/lua/frecency/types.lua
@@ -5,6 +5,7 @@
 ---@class FrecencyPlenaryPath
 ---@field new fun(self: FrecencyPlenaryPath|string, path?: string): FrecencyPlenaryPath
 ---@field absolute fun(): string
+---@field exists fun(self: FrecencyPlenaryPath): boolean
 ---@field is_file fun(self: FrecencyPlenaryPath): boolean
 ---@field filename string
 ---@field joinpath fun(self: FrecencyPlenaryPath, ...): FrecencyPlenaryPath


### PR DESCRIPTION
Fix #200

----

Added this note in doc.

```vim
				      *telescope-frecency-configuration-db_root*
db_root ~

Default: `vim.fn.stdpath "state"`
Type: `string`

Path to the parent directory of custom database location. Defaults to
|$XDG_STATE_HOME|/nvim (see |stdpath()|) if unset.

NOTE: The default value was `vim.fn.stdpath "data"`. If you doesn't set this
option and you have DB in `vim.fn.stdpath "data"` instead of
`vim.fn.stdpath "state"`, it uses the one in the old path for backward
compatibility. See the detail in the issue below.
https://github.com/nvim-telescope/telescope-frecency.nvim/issues/200
```