### PR TITLE
fix: make the path for file_lock unless it exists

### DIFF
--- a/lua/frecency/file_lock.lua
+++ b/lua/frecency/file_lock.lua
@@ -1,3 +1,4 @@
+local Path = require "plenary.path" --[[@as FrecencyPlenaryPath]]
 local async = require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 local log = require "plenary.log"
 
@@ -30,6 +31,13 @@ function FileLock:get()
   local err, fd
   while true do
     count = count + 1
+    local dir = Path.new(self.filename):parent()
+    if not dir:exists() then
+      -- TODO: make this call be async
+      log.debug(("file_lock get(): mkdir parent: %s"):format(dir.filename))
+      ---@diagnostic disable-next-line: undefined-field
+      dir:mkdir { parents = true }
+    end
     err, fd = async.uv.fs_open(self.filename, "wx", tonumber("600", 8))
     if not err then
       break

--- a/lua/frecency/types.lua
+++ b/lua/frecency/types.lua
@@ -10,7 +10,7 @@
 ---@field filename string
 ---@field joinpath fun(self: FrecencyPlenaryPath, ...): FrecencyPlenaryPath
 ---@field make_relative fun(self: FrecencyPlenaryPath, cwd: string): string
----@field parent FrecencyPlenaryPath
+---@field parent fun(self: FrecencyPlenaryPath): FrecencyPlenaryPath
 ---@field path { sep: string }
 ---@field rm fun(self: FrecencyPlenaryPath, opts?: { recursive: boolean }): nil
 ---@field touch fun(self: FrecencyPlenaryPath, opts?: { parents: boolean }): nil


### PR DESCRIPTION
It fails when it gets a file lock and the parent dir does not exist. Fix it.