### PR TITLE
feat: support for multi-part file extensions

### DIFF
--- a/lua/frecency/entry_maker.lua
+++ b/lua/frecency/entry_maker.lua
@@ -119,7 +119,6 @@ function EntryMaker:items(entry, workspace, workspace_tag, formatter)
   end
   if self.web_devicons.is_enabled then
     local basename = utils.path_tail(entry.name)
-    
     table.insert(items, { self.web_devicons:get_icon(basename, utils.file_extension(basename), { default = true }) })
   end
   if config.show_filter_column and workspace and workspace_tag then

--- a/lua/frecency/entry_maker.lua
+++ b/lua/frecency/entry_maker.lua
@@ -118,7 +118,9 @@ function EntryMaker:items(entry, workspace, workspace_tag, formatter)
     end
   end
   if self.web_devicons.is_enabled then
-    table.insert(items, { self.web_devicons:get_icon(entry.name, entry.name:match "%a+$", { default = true }) })
+    local basename = utils.path_tail(entry.name)
+    
+    table.insert(items, { self.web_devicons:get_icon(basename, utils.file_extension(basename), { default = true }) })
   end
   if config.show_filter_column and workspace and workspace_tag then
     local filtered = self:should_show_tail(workspace_tag) and utils.path_tail(workspace) .. Path.path.sep

--- a/lua/frecency/types.lua
+++ b/lua/frecency/types.lua
@@ -152,6 +152,7 @@ function FrecencyPlenaryAsyncUtil.scheduler() end
 ---@field path_tail fun(path: string): string
 ---@field transform_path fun(opts: table, path: string): string, FrecencyTelescopePathStyle[]
 ---@field buf_is_loaded fun(filename: string): boolean
+---@field file_extension fun(filename: string): string
 
 ---@class FrecencyTelescopePicker
 ---@field clear_extra_rows fun(self: FrecencyTelescopePicker, results_bufnr: integer): nil


### PR DESCRIPTION
I commonly work with Laravel, there is a file with extension `.blade.php` and it has an individual icon (the Laravel logo). Currently in telescope-frecency, the file with that extension it still renders in the result picker with the PHP icon. FYI the nvim-web-devicons has this support for the icon at https://github.com/nvim-tree/nvim-web-devicons/pull/442 and telescope also has support for multi-part file extension at https://github.com/nvim-telescope/telescope.nvim/pull/2252. I think it would be nice to add this support in telescope-frecency. Thanks