### PR TITLE
fix: detect case sensitive filenames

### DIFF
--- a/lua/frecency/fs.lua
+++ b/lua/frecency/fs.lua
@@ -17,7 +17,7 @@ local FS = {}
 ---@param fs_config? FrecencyFSConfig
 ---@return FrecencyFS
 FS.new = function(fs_config)
-  local self= setmetatable(
+  local self = setmetatable(
     { config = vim.tbl_extend("force", { scan_depth = 100 }, fs_config or {}), os_homedir = assert(uv.os_homedir()) },
     { __index = FS }
   )
@@ -27,6 +27,17 @@ FS.new = function(fs_config)
     return "^" .. regex .. "$"
   end, config.ignore_patterns)
   return self
+end
+
+---@param path string
+---@return boolean
+function FS:is_ignored(path)
+  for _, regex in ipairs(self.ignore_regexes) do
+    if path:find(regex) then
+      return true
+    end
+  end
+  return false
 end
 
 ---@param path? string
@@ -79,18 +90,6 @@ function FS:starts_with(path, base)
     with_sep[base] = base .. (base:sub(#base) == Path.path.sep and "" or Path.path.sep)
   end
   return path:find(with_sep[base], 1, true) == 1
-end
-
----@private
----@param path string
----@return boolean
-function FS:is_ignored(path)
-  for _, regex in ipairs(self.ignore_regexes) do
-    if path:find(regex) then
-      return true
-    end
-  end
-  return false
 end
 
 ---@private

--- a/lua/frecency/tests/database_spec.lua
+++ b/lua/frecency/tests/database_spec.lua
@@ -5,15 +5,7 @@ local async = require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 local util = require "frecency.tests.util"
 async.tests.add_to_env()
 
----@param datetime string?
----@return integer
-local function make_epoch(datetime)
-  if not datetime then
-    return os.time()
-  end
-  local tz_fix = datetime:gsub("+(%d%d):(%d%d)$", "+%1%2")
-  return util.time_piece(tz_fix)
-end
+local make_epoch = util.make_epoch
 
 local function with_database(f)
   local fs = FS.new {}

--- a/lua/frecency/tests/frecency_spec.lua
+++ b/lua/frecency/tests/frecency_spec.lua
@@ -2,112 +2,14 @@
 -- https://github.com/nvim-lua/plenary.nvim/blob/663246936325062427597964d81d30eaa42ab1e4/lua/plenary/test_harness.lua#L86-L86
 vim.opt.runtimepath:append(vim.env.TELESCOPE_PATH)
 
----@diagnostic disable: invisible, undefined-field
-local Frecency = require "frecency"
-local Picker = require "frecency.picker"
 local util = require "frecency.tests.util"
 local log = require "plenary.log"
-local Path = require "plenary.path"
-local config = require "frecency.config"
 
----@param datetime string?
----@return integer
-local function make_epoch(datetime)
-  if not datetime then
-    return os.time()
-  end
-  local tz_fix = datetime:gsub("+(%d%d):(%d%d)$", "+%1%2")
-  return util.time_piece(tz_fix)
-end
-
----@param files string[]
----@param cb_or_config table|fun(frecency: Frecency, finder: FrecencyFinder, dir: FrecencyPlenaryPath): nil
----@param callback? fun(frecency: Frecency, finder: FrecencyFinder, dir: FrecencyPlenaryPath): nil
----@return nil
-local function with_files(files, cb_or_config, callback)
-  local dir, close = util.make_tree(files)
-  local cfg
-  if type(cb_or_config) == "table" then
-    cfg = vim.tbl_extend("force", { debug = true, db_root = dir.filename }, cb_or_config)
-  else
-    cfg = { debug = true, db_root = dir.filename }
-    callback = cb_or_config
-  end
-  assert(callback)
-  log.debug(cfg)
-  config.setup(cfg)
-  local frecency = Frecency.new()
-  frecency.database.tbl:wait_ready()
-  frecency.picker =
-    Picker.new(frecency.database, frecency.entry_maker, frecency.fs, frecency.recency, { editing_bufnr = 0 })
-  local finder = frecency.picker:finder {}
-  callback(frecency, finder, dir)
-  close()
-end
-
-local function filepath(dir, file)
-  return dir:joinpath(file):absolute()
-end
-
----@param frecency Frecency
----@param dir FrecencyPlenaryPath
----@return fun(file: string, epoch: integer, reset: boolean?): nil
-local function make_register(frecency, dir)
-  return function(file, epoch, reset)
-    local path = filepath(dir, file)
-    vim.cmd.edit(path)
-    local bufnr = assert(vim.fn.bufnr(path))
-    if reset then
-      frecency.buf_registered[bufnr] = nil
-    end
-    frecency:register(bufnr, epoch)
-  end
-end
-
----@param frecency Frecency
----@param dir FrecencyPlenaryPath
----@param callback fun(register: fun(file: string, epoch?: integer): nil): nil
----@return nil
-local function with_fake_register(frecency, dir, callback)
-  local bufnr = 0
-  local buffers = {}
-  local original_nvim_buf_get_name = vim.api.nvim_buf_get_name
-  ---@diagnostic disable-next-line: redefined-local, duplicate-set-field
-  vim.api.nvim_buf_get_name = function(bufnr)
-    return buffers[bufnr]
-  end
-  ---@param file string
-  ---@param epoch integer
-  local function register(file, epoch)
-    local path = filepath(dir, file)
-    Path.new(path):touch()
-    bufnr = bufnr + 1
-    buffers[bufnr] = path
-    frecency:register(bufnr, epoch)
-  end
-  callback(register)
-  vim.api.nvim_buf_get_name = original_nvim_buf_get_name
-end
-
----@param choice "y"|"n"
----@param callback fun(called: fun(): integer): nil
----@return nil
-local function with_fake_vim_ui_select(choice, callback)
-  local original_vim_ui_select = vim.ui.select
-  local count = 0
-  local function called()
-    return count
-  end
-  ---@diagnostic disable-next-line: duplicate-set-field
-  vim.ui.select = function(_, opts, on_choice)
-    count = count + 1
-    log.info(opts.prompt)
-    log.info(opts.format_item(choice))
-    on_choice(choice)
-  end
-  callback(called)
-  vim.ui.select = original_vim_ui_select
-end
+local filepath = util.filepath
+local make_epoch = util.make_epoch
+local make_register = util.make_register
+local with_fake_register = util.with_fake_register
+local with_files = util.with_files
 
 describe("frecency", function()
   describe("register", function()
@@ -116,7 +18,10 @@ describe("frecency", function()
         local register = make_register(frecency, dir)
         local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
         local epoch2 = make_epoch "2023-07-29T01:00:00+09:00"
+        -- HACK: This suspicious 'swapfile' setting is for avoiding E303.
+        vim.o.swapfile = false
         register("hoge1.txt", epoch1)
+        vim.o.swapfile = true
         register("hoge2.txt", epoch2)
 
         it("has valid records in DB", function()
@@ -301,208 +206,6 @@ describe("frecency", function()
     end)
   end)
 
-  describe("validate_database", function()
-    describe("when no files are unlinked", function()
-      with_files({ "hoge1.txt", "hoge2.txt" }, function(frecency, finder, dir)
-        local register = make_register(frecency, dir)
-        local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
-        local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
-        register("hoge1.txt", epoch1)
-        register("hoge2.txt", epoch2)
-
-        it("removes no entries", function()
-          local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
-          assert.are.same({
-            { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
-            { count = 1, path = filepath(dir, "hoge1.txt"), score = 10, timestamps = { epoch1 } },
-          }, results)
-        end)
-      end)
-    end)
-
-    describe("when with not force", function()
-      describe("when files are unlinked but it is less than threshold", function()
-        with_files(
-          { "hoge1.txt", "hoge2.txt", "hoge3.txt", "hoge4.txt", "hoge5.txt" },
-          { db_validate_threshold = 3 },
-          function(frecency, finder, dir)
-            local register = make_register(frecency, dir)
-            local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
-            local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
-            local epoch3 = make_epoch "2023-07-29T00:02:00+09:00"
-            local epoch4 = make_epoch "2023-07-29T00:03:00+09:00"
-            local epoch5 = make_epoch "2023-07-29T00:04:00+09:00"
-            register("hoge1.txt", epoch1)
-            register("hoge2.txt", epoch2)
-            register("hoge3.txt", epoch3)
-            register("hoge4.txt", epoch4)
-            register("hoge5.txt", epoch5)
-            dir:joinpath("hoge1.txt"):rm()
-            dir:joinpath("hoge2.txt"):rm()
-            frecency:validate_database()
-
-            it("removes no entries", function()
-              local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
-              table.sort(results, function(a, b)
-                return a.path < b.path
-              end)
-              assert.are.same({
-                { count = 1, path = filepath(dir, "hoge1.txt"), score = 10, timestamps = { epoch1 } },
-                { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
-                { count = 1, path = filepath(dir, "hoge3.txt"), score = 10, timestamps = { epoch3 } },
-                { count = 1, path = filepath(dir, "hoge4.txt"), score = 10, timestamps = { epoch4 } },
-                { count = 1, path = filepath(dir, "hoge5.txt"), score = 10, timestamps = { epoch5 } },
-              }, results)
-            end)
-          end
-        )
-      end)
-
-      describe("when files are unlinked and it is more than threshold", function()
-        describe('when the user response "yes"', function()
-          with_files(
-            { "hoge1.txt", "hoge2.txt", "hoge3.txt", "hoge4.txt", "hoge5.txt" },
-            { db_validate_threshold = 3 },
-            function(frecency, finder, dir)
-              local register = make_register(frecency, dir)
-              local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
-              local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
-              local epoch3 = make_epoch "2023-07-29T00:02:00+09:00"
-              local epoch4 = make_epoch "2023-07-29T00:03:00+09:00"
-              local epoch5 = make_epoch "2023-07-29T00:04:00+09:00"
-              register("hoge1.txt", epoch1)
-              register("hoge2.txt", epoch2)
-              register("hoge3.txt", epoch3)
-              register("hoge4.txt", epoch4)
-              register("hoge5.txt", epoch5)
-              dir:joinpath("hoge1.txt"):rm()
-              dir:joinpath("hoge2.txt"):rm()
-              dir:joinpath("hoge3.txt"):rm()
-
-              with_fake_vim_ui_select("y", function(called)
-                frecency:validate_database()
-
-                it("called vim.ui.select()", function()
-                  assert.are.same(1, called())
-                end)
-              end)
-
-              it("removes entries", function()
-                local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
-                table.sort(results, function(a, b)
-                  return a.path < b.path
-                end)
-                assert.are.same({
-                  { count = 1, path = filepath(dir, "hoge4.txt"), score = 10, timestamps = { epoch4 } },
-                  { count = 1, path = filepath(dir, "hoge5.txt"), score = 10, timestamps = { epoch5 } },
-                }, results)
-              end)
-            end
-          )
-        end)
-
-        describe('when the user response "no"', function()
-          with_files(
-            { "hoge1.txt", "hoge2.txt", "hoge3.txt", "hoge4.txt", "hoge5.txt" },
-            { db_validate_threshold = 3 },
-            function(frecency, finder, dir)
-              local register = make_register(frecency, dir)
-              local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
-              local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
-              local epoch3 = make_epoch "2023-07-29T00:02:00+09:00"
-              local epoch4 = make_epoch "2023-07-29T00:03:00+09:00"
-              local epoch5 = make_epoch "2023-07-29T00:04:00+09:00"
-              register("hoge1.txt", epoch1)
-              register("hoge2.txt", epoch2)
-              register("hoge3.txt", epoch3)
-              register("hoge4.txt", epoch4)
-              register("hoge5.txt", epoch5)
-              dir:joinpath("hoge1.txt"):rm()
-              dir:joinpath("hoge2.txt"):rm()
-              dir:joinpath("hoge3.txt"):rm()
-
-              with_fake_vim_ui_select("n", function(called)
-                frecency:validate_database()
-
-                it("called vim.ui.select()", function()
-                  assert.are.same(1, called())
-                end)
-              end)
-
-              it("removes no entries", function()
-                local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
-                table.sort(results, function(a, b)
-                  return a.path < b.path
-                end)
-                assert.are.same({
-                  { count = 1, path = filepath(dir, "hoge1.txt"), score = 10, timestamps = { epoch1 } },
-                  { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
-                  { count = 1, path = filepath(dir, "hoge3.txt"), score = 10, timestamps = { epoch3 } },
-                  { count = 1, path = filepath(dir, "hoge4.txt"), score = 10, timestamps = { epoch4 } },
-                  { count = 1, path = filepath(dir, "hoge5.txt"), score = 10, timestamps = { epoch5 } },
-                }, results)
-              end)
-            end
-          )
-        end)
-      end)
-    end)
-
-    describe("when with force", function()
-      describe("when db_safe_mode is true", function()
-        with_files({ "hoge1.txt", "hoge2.txt" }, function(frecency, finder, dir)
-          local register = make_register(frecency, dir)
-          local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
-          local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
-          register("hoge1.txt", epoch1)
-          register("hoge2.txt", epoch2)
-          dir:joinpath("hoge1.txt"):rm()
-
-          with_fake_vim_ui_select("y", function(called)
-            frecency:validate_database(true)
-
-            it("called vim.ui.select()", function()
-              assert.are.same(1, called())
-            end)
-          end)
-
-          it("needs confirmation for removing entries", function()
-            local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
-            assert.are.same({
-              { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
-            }, results)
-          end)
-        end)
-      end)
-
-      describe("when db_safe_mode is false", function()
-        with_files({ "hoge1.txt", "hoge2.txt" }, { db_safe_mode = false }, function(frecency, finder, dir)
-          local register = make_register(frecency, dir)
-          local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
-          local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
-          register("hoge1.txt", epoch1)
-          register("hoge2.txt", epoch2)
-          dir:joinpath("hoge1.txt"):rm()
-
-          with_fake_vim_ui_select("y", function(called)
-            frecency:validate_database(true)
-
-            it("did not call vim.ui.select()", function()
-              assert.are.same(0, called())
-            end)
-          end)
-
-          it("needs no confirmation for removing entries", function()
-            local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
-            assert.are.same({
-              { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
-            }, results)
-          end)
-        end)
-      end)
-    end)
-  end)
-
   describe("delete", function()
     describe("when file exists", function()
       with_files({ "hoge1.txt", "hoge2.txt" }, function(frecency, finder, dir)
@@ -515,8 +218,9 @@ describe("frecency", function()
         it("deletes the file successfully", function()
           local path = filepath(dir, "hoge2.txt")
           local result
-          ---@diagnostic disable-next-line: duplicate-set-field
+          ---@diagnostic disable-next-line: duplicate-set-field, invisible
           frecency.notify = function(self, fmt, ...)
+            ---@diagnostic disable-next-line: invisible
             vim.notify(self:message(fmt, ...))
             result = true
           end

--- a/lua/frecency/tests/frecency_validate_database_spec.lua
+++ b/lua/frecency/tests/frecency_validate_database_spec.lua
@@ -1,0 +1,258 @@
+local util = require "frecency.tests.util"
+local async = require "plenary.async"
+
+local filepath = util.filepath
+local make_epoch = util.make_epoch
+local make_register = util.make_register
+local with_fake_vim_ui_select = util.with_fake_vim_ui_select
+local with_files = util.with_files
+
+-- HACK: avoid error:
+-- E5560: nvim_echo must not be called in a lua loop callback
+vim.notify = function(_, _) end
+
+describe("frecency", function()
+  describe("validate_database", function()
+    describe("when no files are unlinked", function()
+      with_files({ "hoge1.txt", "hoge2.txt" }, function(frecency, finder, dir)
+        local register = make_register(frecency, dir)
+        local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
+        local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
+        register("hoge1.txt", epoch1)
+        register("hoge2.txt", epoch2)
+
+        it("removes no entries", function()
+          local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
+          assert.are.same({
+            { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
+            { count = 1, path = filepath(dir, "hoge1.txt"), score = 10, timestamps = { epoch1 } },
+          }, results)
+        end)
+      end)
+    end)
+
+    describe("when with not force", function()
+      describe("when files are unlinked but it is less than threshold", function()
+        with_files(
+          { "hoge1.txt", "hoge2.txt", "hoge3.txt", "hoge4.txt", "hoge5.txt" },
+          { db_validate_threshold = 3 },
+          function(frecency, finder, dir)
+            local register = make_register(frecency, dir)
+            local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
+            local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
+            local epoch3 = make_epoch "2023-07-29T00:02:00+09:00"
+            local epoch4 = make_epoch "2023-07-29T00:03:00+09:00"
+            local epoch5 = make_epoch "2023-07-29T00:04:00+09:00"
+            register("hoge1.txt", epoch1)
+            register("hoge2.txt", epoch2)
+            register("hoge3.txt", epoch3)
+            register("hoge4.txt", epoch4)
+            register("hoge5.txt", epoch5)
+            dir:joinpath("hoge1.txt"):rm()
+            dir:joinpath("hoge2.txt"):rm()
+            async.util.block_on(function()
+              frecency:validate_database()
+            end)
+
+            it("removes no entries", function()
+              local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
+              table.sort(results, function(a, b)
+                return a.path < b.path
+              end)
+              assert.are.same({
+                { count = 1, path = filepath(dir, "hoge1.txt"), score = 10, timestamps = { epoch1 } },
+                { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
+                { count = 1, path = filepath(dir, "hoge3.txt"), score = 10, timestamps = { epoch3 } },
+                { count = 1, path = filepath(dir, "hoge4.txt"), score = 10, timestamps = { epoch4 } },
+                { count = 1, path = filepath(dir, "hoge5.txt"), score = 10, timestamps = { epoch5 } },
+              }, results)
+            end)
+          end
+        )
+      end)
+
+      describe("when files are unlinked and it is more than threshold", function()
+        describe('when the user response "yes"', function()
+          with_files(
+            { "hoge1.txt", "hoge2.txt", "hoge3.txt", "hoge4.txt", "hoge5.txt" },
+            { db_validate_threshold = 3 },
+            function(frecency, finder, dir)
+              local register = make_register(frecency, dir)
+              local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
+              local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
+              local epoch3 = make_epoch "2023-07-29T00:02:00+09:00"
+              local epoch4 = make_epoch "2023-07-29T00:03:00+09:00"
+              local epoch5 = make_epoch "2023-07-29T00:04:00+09:00"
+              register("hoge1.txt", epoch1)
+              register("hoge2.txt", epoch2)
+              register("hoge3.txt", epoch3)
+              register("hoge4.txt", epoch4)
+              register("hoge5.txt", epoch5)
+              dir:joinpath("hoge1.txt"):rm()
+              dir:joinpath("hoge2.txt"):rm()
+              dir:joinpath("hoge3.txt"):rm()
+
+              with_fake_vim_ui_select("y", function(called)
+                async.util.block_on(function()
+                  frecency:validate_database()
+                end)
+
+                it("called vim.ui.select()", function()
+                  assert.are.same(1, called())
+                end)
+              end)
+
+              it("removes entries", function()
+                local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
+                table.sort(results, function(a, b)
+                  return a.path < b.path
+                end)
+                assert.are.same({
+                  { count = 1, path = filepath(dir, "hoge4.txt"), score = 10, timestamps = { epoch4 } },
+                  { count = 1, path = filepath(dir, "hoge5.txt"), score = 10, timestamps = { epoch5 } },
+                }, results)
+              end)
+            end
+          )
+        end)
+
+        describe('when the user response "no"', function()
+          with_files(
+            { "hoge1.txt", "hoge2.txt", "hoge3.txt", "hoge4.txt", "hoge5.txt" },
+            { db_validate_threshold = 3 },
+            function(frecency, finder, dir)
+              local register = make_register(frecency, dir)
+              local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
+              local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
+              local epoch3 = make_epoch "2023-07-29T00:02:00+09:00"
+              local epoch4 = make_epoch "2023-07-29T00:03:00+09:00"
+              local epoch5 = make_epoch "2023-07-29T00:04:00+09:00"
+              register("hoge1.txt", epoch1)
+              register("hoge2.txt", epoch2)
+              register("hoge3.txt", epoch3)
+              register("hoge4.txt", epoch4)
+              register("hoge5.txt", epoch5)
+              dir:joinpath("hoge1.txt"):rm()
+              dir:joinpath("hoge2.txt"):rm()
+              dir:joinpath("hoge3.txt"):rm()
+
+              with_fake_vim_ui_select("n", function(called)
+                async.util.block_on(function()
+                  frecency:validate_database()
+                end)
+
+                it("called vim.ui.select()", function()
+                  assert.are.same(1, called())
+                end)
+              end)
+
+              it("removes no entries", function()
+                local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
+                table.sort(results, function(a, b)
+                  return a.path < b.path
+                end)
+                assert.are.same({
+                  { count = 1, path = filepath(dir, "hoge1.txt"), score = 10, timestamps = { epoch1 } },
+                  { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
+                  { count = 1, path = filepath(dir, "hoge3.txt"), score = 10, timestamps = { epoch3 } },
+                  { count = 1, path = filepath(dir, "hoge4.txt"), score = 10, timestamps = { epoch4 } },
+                  { count = 1, path = filepath(dir, "hoge5.txt"), score = 10, timestamps = { epoch5 } },
+                }, results)
+              end)
+            end
+          )
+        end)
+      end)
+    end)
+
+    describe("when with force", function()
+      describe("when db_safe_mode is true", function()
+        with_files({ "hoge1.txt", "hoge2.txt" }, function(frecency, finder, dir)
+          local register = make_register(frecency, dir)
+          local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
+          local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
+          register("hoge1.txt", epoch1)
+          register("hoge2.txt", epoch2)
+          dir:joinpath("hoge1.txt"):rm()
+
+          with_fake_vim_ui_select("y", function(called)
+            async.util.block_on(function()
+              frecency:validate_database(true)
+            end)
+
+            it("called vim.ui.select()", function()
+              assert.are.same(1, called())
+            end)
+          end)
+
+          it("needs confirmation for removing entries", function()
+            local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
+            assert.are.same({
+              { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
+            }, results)
+          end)
+        end)
+      end)
+
+      describe("when db_safe_mode is false", function()
+        with_files({ "hoge1.txt", "hoge2.txt" }, { db_safe_mode = false }, function(frecency, finder, dir)
+          local register = make_register(frecency, dir)
+          local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
+          local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
+          register("hoge1.txt", epoch1)
+          register("hoge2.txt", epoch2)
+          dir:joinpath("hoge1.txt"):rm()
+
+          with_fake_vim_ui_select("y", function(called)
+            async.util.block_on(function()
+              frecency:validate_database(true)
+            end)
+
+            it("did not call vim.ui.select()", function()
+              assert.are.same(0, called())
+            end)
+          end)
+
+          it("needs no confirmation for removing entries", function()
+            local results = finder:get_results(nil, make_epoch "2023-07-29T02:00:00+09:00")
+            assert.are.same({
+              { count = 1, path = filepath(dir, "hoge2.txt"), score = 10, timestamps = { epoch2 } },
+            }, results)
+          end)
+        end)
+      end)
+    end)
+
+    describe("when case sensive filename", function()
+      with_files({ "hoge1.txt", "hoge2.txt" }, function(frecency, finder, dir)
+        local register = make_register(frecency, dir)
+        local epoch1 = make_epoch "2023-07-29T00:00:00+09:00"
+        local epoch2 = make_epoch "2023-07-29T00:01:00+09:00"
+        local epoch3 = make_epoch "2023-07-29T00:02:00+09:00"
+        register("hoge1.txt", epoch1)
+        register("hoge2.txt", epoch2, nil, true)
+        dir:joinpath("hoge1.txt"):rm()
+        dir:joinpath("hoge2.txt"):rename { new_name = dir:joinpath("_hoge2.txt").filename }
+        dir:joinpath("_hoge2.txt"):rename { new_name = dir:joinpath("Hoge2.txt").filename }
+        register("Hoge2.txt", epoch3)
+
+        with_fake_vim_ui_select("y", function(called)
+          async.util.block_on(function()
+            frecency:validate_database(true)
+          end)
+
+          it("calls vim.ui.select()", function()
+            assert.are.same(1, called())
+          end)
+        end)
+
+        it("removes duplicated case sensitive filenames", function()
+          local results = finder:get_results(nil, make_epoch "2023-07-29T03:00:00+09:00")
+          assert.are.same({
+            { count = 1, path = filepath(dir, "Hoge2.txt"), score = 10, timestamps = { epoch3 } },
+          }, results)
+        end)
+      end)
+    end)
+  end)
+end)

--- a/lua/frecency/types.lua
+++ b/lua/frecency/types.lua
@@ -12,6 +12,7 @@
 ---@field make_relative fun(self: FrecencyPlenaryPath, cwd: string): string
 ---@field parent fun(self: FrecencyPlenaryPath): FrecencyPlenaryPath
 ---@field path { sep: string }
+---@field rename fun(self: FrecencyPlenaryPath, opts: { new_name: string }): nil
 ---@field rm fun(self: FrecencyPlenaryPath, opts?: { recursive: boolean }): nil
 ---@field touch fun(self: FrecencyPlenaryPath, opts?: { parents: boolean }): nil
 
@@ -93,6 +94,18 @@ function FrecencyPlenaryAsyncUv.fs_stat(path) end
 function FrecencyPlenaryAsyncUv.fs_open(path, flags, mode) end
 
 ---@async
+---@param path string
+---@return string? err
+---@return integer? fs
+function FrecencyPlenaryAsyncUv.fs_scandir(path) end
+
+---@param fs integer
+---@return string? err
+---@return string? name
+---@return string? type
+function FrecencyPlenaryAsyncUv.fs_scandir_next(fs) end
+
+---@async
 ---@param fd integer
 ---@param size integer
 ---@param offset? integer
@@ -118,6 +131,11 @@ function FrecencyPlenaryAsyncUv.fs_unlink(path) end
 ---@param fd integer
 ---@return string? err
 function FrecencyPlenaryAsyncUv.fs_close(fd) end
+
+---@async
+---@param async_fns (async fun(...): ...)[]
+---@return table
+function FrecencyPlenaryAsyncUtil.join(async_fns) end
 
 ---@async
 ---@param ms integer

--- a/lua/frecency/types.lua
+++ b/lua/frecency/types.lua
@@ -96,6 +96,12 @@ function FrecencyPlenaryAsyncUv.fs_open(path, flags, mode) end
 ---@async
 ---@param path string
 ---@return string? err
+---@return string? path
+function FrecencyPlenaryAsyncUv.fs_realpath(path) end
+
+---@async
+---@param path string
+---@return string? err
 ---@return integer? fs
 function FrecencyPlenaryAsyncUv.fs_scandir(path) end
 

--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -7,7 +7,7 @@
 ---@field query fun(opts?: FrecencyQueryOpts): FrecencyQueryEntry[]|string[]
 ---@field register fun(bufnr: integer, datetime: string?): nil
 ---@field start fun(opts: FrecencyPickerOptions?): nil
----@field validate_database fun(force: boolean?): nil
+---@field validate_database async fun(force: boolean?): nil
 local frecency = setmetatable({}, {
   ---@param self FrecencyInstance
   ---@param key "complete"|"delete"|"register"|"start"|"validate_database"
@@ -47,7 +47,7 @@ return require("telescope").register_extension {
 
     ---@param cmd_info { bang: boolean }
     vim.api.nvim_create_user_command("FrecencyValidate", function(cmd_info)
-      frecency.validate_database(cmd_info.bang)
+      require("plenary.async").void(frecency.validate_database)(cmd_info.bang)
     end, { bang = true, desc = "Clean up DB for telescope-frecency" })
 
     vim.api.nvim_create_user_command("FrecencyDelete", function(info)


### PR DESCRIPTION
Fix https://github.com/nvim-telescope/telescope-frecency.nvim/issues/207

Now `frecency.validate_database` detects case sensitive filenames and
delete if it is not found. For example, now it deletes `foo.lua` even if
`Foo.lua` still exists.

For performance issue, this function is now an async function, so you
should wrap it with `async.void` to call.