### PR TITLE
fix(icons): improve fallback for multi-part file extensions

### DIFF
--- a/lua/frecency/entry_maker.lua
+++ b/lua/frecency/entry_maker.lua
@@ -119,7 +119,12 @@ function EntryMaker:items(entry, workspace, workspace_tag, formatter)
   end
   if self.web_devicons.is_enabled then
     local basename = utils.path_tail(entry.name)
-    table.insert(items, { self.web_devicons:get_icon(basename, utils.file_extension(basename), { default = true }) })
+    local icon, icon_highlight =
+      self.web_devicons:get_icon(basename, utils.file_extension(basename), { default = false })
+    if not icon then
+      icon, icon_highlight = self.web_devicons:get_icon(basename, nil, { default = true })
+    end
+    table.insert(items, { icon, icon_highlight })
   end
   if config.show_filter_column and workspace and workspace_tag then
     local filtered = self:should_show_tail(workspace_tag) and utils.path_tail(workspace) .. Path.path.sep


### PR DESCRIPTION
Following PR #215, I realized I forgot to handle the fallback case for files with multi-part extensions that don't have a specific icon. For example, a file with the filename `test.js.LICENSE.txt` should render the icon for `.txt` instead of the default icon.

Here is some screenshot
Before
![image](https://github.com/user-attachments/assets/22fd8492-42ac-4696-b039-3c9d88c64340)

After
![image](https://github.com/user-attachments/assets/22c1ba83-1289-44d8-b3a8-ae7ba73c5dc0)
