### PR TITLE
fix: avoid errors caused by echoing messages

### DIFF
--- a/lua/frecency/klass.lua
+++ b/lua/frecency/klass.lua
@@ -47,7 +47,7 @@ function Frecency:setup()
       return done
     end)
     if not ok then
-      log.error("failed to setup:", status == -1 and "timed out" or "interrupted")
+      error("failed to setup:" .. (status == -1 and "timed out" or "interrupted"))
     end
   end
 end


### PR DESCRIPTION
This error below occurs when it takes long time to init the plugin.

E5560: nvim_echo must not be called in a lua loop callback