### PR TITLE
fix: avoid errors occured by async.util.join

### DIFF
--- a/lua/frecency/database.lua
+++ b/lua/frecency/database.lua
@@ -116,14 +116,17 @@ end
 ---@async
 ---@return string[]
 function Database:unlinked_entries()
-  return vim.tbl_flatten(async.util.join(vim.tbl_map(function(path)
+  -- HACK: async.util.join() does not work with empty table. So when the table
+  -- has no entries, return early.
+  local async_fns = vim.tbl_map(function(path)
     return function()
       local err, realpath = async.uv.fs_realpath(path)
       if err or not realpath or realpath ~= path or fs.is_ignored(realpath) then
         return path
       end
     end
-  end, vim.tbl_keys(self.tbl.records))))
+  end, vim.tbl_keys(self.tbl.records))
+  return #async_fns > 0 and vim.tbl_flatten(async.util.join(async_fns)) or {}
 end
 
 ---@async


### PR DESCRIPTION
This avoids errors when DB does not exist or has no entry.