### PR TITLE
fix: icon colors

### DIFF
--- a/lua/frecency/web_devicons.lua
+++ b/lua/frecency/web_devicons.lua
@@ -6,8 +6,11 @@ local M = {
   ---@return string
   ---@return string
   get_icon = function(name, ext, opts)
-    local ok, web_devicons = pcall(require, "nvim-web-devicons")
-    return ok and web_devicons.get_icon(name, ext, opts) or "", ""
+    local ok, web_devicons = pcall(require, "nvim-web-devicons", opts)
+    if not ok then
+      return "", ""
+    end
+    return web_devicons.get_icon(name, ext)
   end,
 }
 


### PR DESCRIPTION
|Current|Updated|
|-|-|
|![Screenshot_20240827_194447](https://github.com/user-attachments/assets/6638c658-cb3e-4ec4-9080-26efa5555df8)|![Screenshot_20240827_194452](https://github.com/user-attachments/assets/4270109c-2ea9-4ec1-ab05-0ec9938ef556)|

The bug happens due to the nature of `nvim-web-devicons`'s `get_icon` function because it does not always return the icon name an highlight.

> ```lua
>  ...
>  if icon_data then
>    return icon_data.icon, get_highlight_name(icon_data)
>  end
> ```

Reference to the functions code: https://github.com/nvim-tree/nvim-web-devicons/blob/3722e3d1fb5fe1896a104eb489e8f8651260b520/lua/nvim-web-devicons.lua#L499-L505

Due to this, the current use `or "", ""` is not only the fallback when `ok` is false but also for regular `get_icon` calls. 

The changes handle `not ok` explicitly to prevent this.
