### PR TITLE
feat: enable to load without { main = "frecency" }

### DIFF
--- a/lua/telescope-frecency.lua
+++ b/lua/telescope-frecency.lua
@@ -1,0 +1,1 @@
+return require "frecency"


### PR DESCRIPTION
With this, we can load telescope-frecency.nvim without `main = "frecency"` option in lazy.nvim.