### PR TITLE
fix: remove hack that is causing validation not to appear

### DIFF
--- a/lua/frecency/klass.lua
+++ b/lua/frecency/klass.lua
@@ -138,9 +138,6 @@ function Frecency:_validate_database(force)
     timer.track "validate_database() finish: removed"
     return
   end
-  -- HACK: This is needed because the default implementaion of vim.ui.select()
-  -- uses vim.fn.* function and it makes E5560 error.
-  async.util.scheduler()
   vim.ui.select({ "y", "n" }, {
     prompt = "\n" .. self:message("remove %d entries from database?", #unlinked),
     ---@param item "y"|"n"


### PR DESCRIPTION
With the recently added hack the UI select for database validation stopped working. The PR removes the hack to restore the functionality.

The hack was introduced to resolve #246. But since it's not possible to reproduce the error the issue is mentioning and there were also other changes, it can be assumed that it was not the hack that has fixed the issue. So it should be removed since it introduces other conflicts.

Tested with nvim 10.1 and nightly(2024-09-06).