### PR TITLE
feat: enable to use multi dirs for each workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,18 @@ Frecency tackles this with *Workspace Filters*:
 
 The workspace filter feature enables you to select from user defined _filter
 tags_ that map to a directory or collection of directories. Filters are applied
-by entering `:workspace_tag:` anywhere in the query. Filter name completion is
-available by pressing `<Tab>` after the first `:` character.
+by entering `:workspace_tag:` anywhere in the query. You can complete names by
+pressing `<Tab>` after the first `:` character (in default setting).
 
 When a filter is applied, results are reduced to entries whose path is a
-descendant of the workspace directory. The indexed results are optionally
+descendant of the workspace directories. The indexed results are optionally
 augmented with a listing of _all_ files found in a recursive search of the
-workspace directory. Non-indexed files are given a score of zero and appear
-below the 'frecent' entries. When a non-indexed file is opened, it gains a
-score value and is available in future 'frecent' search results.
+workspace directories. Non-indexed files are given a score of zero and appear
+below the _frecent_ entries. When a non-indexed file is opened, it gains a
+score value and is available in future _frecent_ search results.
+
+In default, pre-defined workspace tag: `CWD` is available. that is, you can
+filter entries into ones under the current working directory.
 
 If the active buffer (prior to the finder being launched) is attached to an LSP
 server, an automatic `LSP` tag is available, which maps to the workspace
@@ -85,7 +88,7 @@ See `:h telescope-frecency-configuration` to know about further configurations.
 
 Filter tags are applied by typing the `:tag:` name (adding surrounding colons)
 in the finder query. Entering `:<Tab>` will trigger omni completion for
-available tags.
+available tags (in default setting).
 
 ## References
 

--- a/doc/telescope-frecency.txt
+++ b/doc/telescope-frecency.txt
@@ -83,20 +83,27 @@ Frecency tackles this with “Workspace Filters”.
 WORKSPACE FILTER	      *telescope-frecency-introduction-workspace-filter*
 
 This feature enables you to select from user defined “filter tags” that map to
-a directory or collection of directories. Filters are applied by entering
-`:workspace_tag:` anywhere in the query. Filter name completion is available by
-pressing `<Tab>` after the first `:` character.
+a directory or a collection of directories. Filters are applied by entering
+`:workspace_tag:` anywhere in the query. You can complete names by pressing
+`<Tab>` after the first `:` character (see
+|telescope-frecency-configuration-enable_prompt_mappings|).
 
 When a filter is applied, results are reduced to entries whose path is a
-descendant of the workspace directory. The indexed results are optionally
+descendant of the workspace directories. The indexed results are optionally
 augmented with a listing of “all” files found in a recursive search of the
-workspace directory. Non-indexed files are given a score of zero and appear
+workspace directories. Non-indexed files are given a score of zero and appear
 below the “frecent” entries. When a non-indexed file is opened, it gains a
 score value and is available in future “frecent” search results.
+
+In default, pre-defined workspace tag: `CWD` is available, that is, you can
+filter entries into ones under the current working directory.
 
 If the active buffer (prior to the finder being launched) is attached to an
 LSP server, an automatic `LSP` tag is available, which maps to the workspace
 directories provided by the language server.
+
+You can define other workspace tags by an option:
+|telescope-frecency-configuration-workspaces|.
 
 
 ==============================================================================
@@ -707,18 +714,26 @@ because of performance consideration.
 workspaces ~
 
 Default: `{}`
-Type: `table<string, string>`
+Type: `table<string, string[]>`
 
-This table contains mappings of `workspace_tag` → `workspace_directory`. The key
-corresponds to the `:tag_name` used to select the filter in queries. The value
-corresponds to the top level directory by which results will be filtered.
+This table contains mappings of `workspace_tag` → `workspace_directories`. The key
+corresponds to the `:tag_name:` used to select the filter in queries. The value
+corresponds to the top level directories by which results will be filtered.
+
+When multiple directories are set to one `workspace_tag` such as `:PJT:` in this
+example setting below, you can show entries containing results filtered with
+each directory.
 >lua
     -- example configuration
     workspaces = {
-      ["conf"] = "/home/my_username/.config",
-      ["data"] = "/home/my_username/.local/share",
-      ["project"] = "/home/my_username/projects",
-      ["wiki"] = "/home/my_username/wiki",
+      CONF = "/home/my_username/.config",
+      DATA = "/home/my_username/.local/share",
+      WIKI = "/home/my_username/wiki",
+      PJT = {
+        "/home/my_username/project_foo",
+        "/home/my_username/project_bar",
+        "/home/my_username/project_foobar",
+      },
     }
 
 

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -25,7 +25,7 @@ local os_util = require "frecency.os_util"
 ---@field show_scores? boolean default: false
 ---@field show_unindexed? boolean default: true
 ---@field workspace_scan_cmd? "LUA"|string[] default: nil
----@field workspaces? table<string, string> default: {}
+---@field workspaces? table<string, string|string[]> default: {}
 
 ---@class FrecencyConfig: FrecencyRawConfig
 ---@field ext_config FrecencyRawConfig
@@ -57,7 +57,7 @@ local Config = {}
 ---@field show_scores boolean default: false
 ---@field show_unindexed boolean default: true
 ---@field workspace_scan_cmd? "LUA"|string[] default: nil
----@field workspaces table<string, string> default: {}
+---@field workspaces table<string, string|string[]> default: {}
 
 ---@return FrecencyConfig
 Config.new = function()

--- a/lua/frecency/database.lua
+++ b/lua/frecency/database.lua
@@ -170,14 +170,27 @@ function Database:update(path, epoch)
 end
 
 ---@async
----@param workspace? string
+---@param workspaces? string[]
 ---@param epoch? integer
 ---@return FrecencyDatabaseEntry[]
-function Database:get_entries(workspace, epoch)
+function Database:get_entries(workspaces, epoch)
   local now = epoch or os.time()
+  ---@param path string
+  ---@return boolean
+  local function in_workspace(path)
+    if not workspaces then
+      return true
+    end
+    for _, workspace in ipairs(workspaces) do
+      if fs.starts_with(path, workspace) then
+        return true
+      end
+    end
+    return false
+  end
   local items = {}
   for path, record in pairs(self.tbl.records) do
-    if fs.starts_with(path, workspace) then
+    if in_workspace(path) then
       table.insert(items, {
         path = path,
         count = record.count,

--- a/lua/frecency/finder.lua
+++ b/lua/frecency/finder.lua
@@ -14,7 +14,7 @@ local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 ---@field entries FrecencyEntry[]
 ---@field scanned_entries FrecencyEntry[]
 ---@field entry_maker FrecencyEntryMakerInstance
----@field path? string
+---@field paths? string[]
 ---@field private database FrecencyDatabase
 ---@field private rx FrecencyPlenaryAsyncControlChannelRx
 ---@field private tx FrecencyPlenaryAsyncControlChannelTx
@@ -23,9 +23,40 @@ local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 ---@field private need_scan_db boolean
 ---@field private need_scan_dir boolean
 ---@field private seen table<string, boolean>
----@field private process VimSystemObj?
+---@field private process table<string, { obj: VimSystemObj, done: boolean }>
 ---@field private state FrecencyState
-local Finder = {}
+local Finder = {
+  ---@type fun(): string[]?
+  cmd = (function()
+    local candidates = {
+      { "fdfind", "-Htf", "-E", ".git" },
+      { "fd", "-Htf", "-E", ".git" },
+      { "rg", "-.g", "!.git", "--files" },
+    }
+    ---@type string[]?
+    local cache
+    return function()
+      if not cache then
+        for _, candidate in ipairs(candidates) do
+          if vim.system then
+            if pcall(vim.system, { candidate[1], "--version" }) then
+              cache = candidate
+              break
+            end
+          elseif
+            pcall(function()
+              Job:new { command = candidate[1], args = { "--version" } }
+            end)
+          then
+            cache = candidate
+            break
+          end
+        end
+      end
+      return cache
+    end
+  end)(),
+}
 
 ---@class FrecencyFinderConfig
 ---@field chunk_size? integer default: 1000
@@ -35,11 +66,11 @@ local Finder = {}
 ---@param database FrecencyDatabase
 ---@param entry_maker FrecencyEntryMakerInstance
 ---@param need_scandir boolean
----@param path string?
+---@param paths string[]?
 ---@param state FrecencyState
 ---@param finder_config? FrecencyFinderConfig
 ---@return FrecencyFinder
-Finder.new = function(database, entry_maker, need_scandir, path, state, finder_config)
+Finder.new = function(database, entry_maker, need_scandir, paths, state, finder_config)
   local tx, rx = async.control.channel.mpsc()
   local scan_tx, scan_rx = async.control.channel.mpsc()
   local self = setmetatable({
@@ -47,14 +78,15 @@ Finder.new = function(database, entry_maker, need_scandir, path, state, finder_c
     closed = false,
     database = database,
     entry_maker = entry_maker,
-    path = path,
+    paths = paths,
+    process = {},
     state = state,
 
     seen = {},
     entries = {},
     scanned_entries = {},
     need_scan_db = true,
-    need_scan_dir = need_scandir and path,
+    need_scan_dir = need_scandir and not not paths,
     rx = rx,
     tx = tx,
     scan_rx = scan_rx,
@@ -77,44 +109,48 @@ end
 ---@param epoch? integer
 ---@return nil
 function Finder:start(epoch)
-  local ok
+  ---@type table<string, boolean>
+  local results = {}
   if config.workspace_scan_cmd ~= "LUA" and self.need_scan_dir then
-    ---@type string[][]
-    local cmds = config.workspace_scan_cmd and { config.workspace_scan_cmd }
-      or { { "fdfind", "-Htf", "-E", ".git" }, { "fd", "-Htf", "-E", ".git" }, { "rg", "-.g", "!.git", "--files" } }
-    for _, c in ipairs(cmds) do
-      ok = self:scan_dir_cmd(c)
-      if ok then
-        log.debug("scan_dir_cmd: " .. vim.inspect(c))
-        break
+    local cmd = config.workspace_scan_cmd --[=[@as string[]]=]
+      or Finder.cmd()
+    if cmd then
+      for _, path in ipairs(self.paths) do
+        log.debug(("scan_dir_cmd: %s: %s"):format(vim.inspect(cmd), path))
+        results[path] = self:scan_dir_cmd(path, cmd)
       end
     end
   end
   async.void(function()
     -- NOTE: return to the main loop to show the main window
     async.util.scheduler()
-    for _, file in ipairs(self:get_results(self.path, epoch)) do
+    for _, file in ipairs(self:get_results(self.paths, epoch)) do
       file.path = os_util.normalize_sep(file.path)
       local entry = self.entry_maker(file)
       self.tx.send(entry)
     end
     self.tx.send(nil)
-    if self.need_scan_dir and not ok then
-      log.debug "scan_dir_lua"
-      async.util.scheduler()
-      self:scan_dir_lua()
+    if self.need_scan_dir then
+      for _, path in pairs(self.paths) do
+        if not results[path] then
+          log.debug("scan_dir_lua: " .. path)
+          async.util.scheduler()
+          self:scan_dir_lua(path)
+        end
+      end
     end
   end)()
 end
 
+---@param path string
 ---@param cmd string[]
 ---@return boolean
-function Finder:scan_dir_cmd(cmd)
+function Finder:scan_dir_cmd(path, cmd)
   local function stdout(err, chunk)
     if not self.closed and not err and chunk then
       for name in chunk:gmatch "[^\n]+" do
         local cleaned = name:gsub("^%./", "")
-        local fullpath = os_util.join_path(self.path, cleaned)
+        local fullpath = os_util.join_path(path, cleaned)
         local entry = self.entry_maker { id = 0, count = 0, path = fullpath, score = 0 }
         self.scan_tx.send(entry)
       end
@@ -122,22 +158,31 @@ function Finder:scan_dir_cmd(cmd)
   end
 
   local function on_exit()
-    self.process = nil
-    self:close()
-    self.scan_tx.send(nil)
+    self.process[path] = { done = true }
+    local done_all = true
+    for _, p in ipairs(self.paths) do
+      if not self.process[p] or not self.process[p].done then
+        done_all = false
+        break
+      end
+    end
+    if done_all then
+      self:close()
+      self.scan_tx.send(nil)
+    end
   end
 
-  local ok
+  local ok, process
   if vim.system then
     ---@diagnostic disable-next-line: assign-type-mismatch
-    ok, self.process = pcall(vim.system, cmd, {
-      cwd = self.path,
+    ok, process = pcall(vim.system, cmd, {
+      cwd = path,
       text = true,
       stdout = stdout,
     }, on_exit)
   else
     -- for Neovim v0.9.x
-    ok, self.process = pcall(function()
+    ok, process = pcall(function()
       local args = {}
       for i, arg in ipairs(cmd) do
         if i > 1 then
@@ -146,7 +191,7 @@ function Finder:scan_dir_cmd(cmd)
       end
       log.debug { cmd = cmd[1], args = args }
       local job = Job:new {
-        cwd = self.path,
+        cwd = path,
         command = cmd[1],
         args = args,
         on_stdout = stdout,
@@ -156,21 +201,25 @@ function Finder:scan_dir_cmd(cmd)
       return job.handle
     end)
   end
-  if not ok then
-    self.process = nil
+  if ok then
+    self.process[path] = {
+      obj = process --[[@as VimSystemObj]],
+      done = false,
+    }
   end
   return ok
 end
 
 ---@async
+---@param path string
 ---@return nil
-function Finder:scan_dir_lua()
+function Finder:scan_dir_lua(path)
   local count = 0
-  for name in fs.scan_dir(self.path) do
+  for name in fs.scan_dir(path) do
     if self.closed then
       break
     end
-    local fullpath = os_util.join_path(self.path, name)
+    local fullpath = os_util.join_path(path, name)
     local entry = self.entry_maker { id = 0, count = 0, path = fullpath, score = 0 }
     self.scan_tx.send(entry)
     count = count + 1
@@ -213,7 +262,7 @@ end
 ---@param process_result fun(entry: FrecencyEntry): nil
 ---@param entries FrecencyEntry[]
 ---@return boolean?
-function Finder:process_table(process_result, entries)
+function Finder.process_table(_, process_result, entries)
   for _, entry in ipairs(entries) do
     if process_result(entry) then
       return true
@@ -252,13 +301,13 @@ function Finder:process_channel(process_result, entries, rx, start_index)
   end
 end
 
----@param workspace? string
+---@param workspaces? string[]
 ---@param epoch? integer
 ---@return FrecencyFile[]
-function Finder:get_results(workspace, epoch)
-  log.debug { workspace = workspace or "NONE" }
+function Finder:get_results(workspaces, epoch)
+  log.debug { workspaces = workspaces or "NONE" }
   timer.track "fetching start"
-  local files = self.database:get_entries(workspace, epoch)
+  local files = self.database:get_entries(workspaces, epoch)
   timer.track "fetching finish"
   for _, file in ipairs(files) do
     file.score = file.ages and recency.calculate(file.count, file.ages) or 0
@@ -275,8 +324,10 @@ end
 
 function Finder:close()
   self.closed = true
-  if self.process then
-    self.process:kill(9)
+  for _, process in pairs(self.process) do
+    if not process.done then
+      process.obj:kill(9)
+    end
   end
 end
 

--- a/lua/frecency/klass.lua
+++ b/lua/frecency/klass.lua
@@ -204,7 +204,7 @@ end
 ---@field limit? integer default: 100
 ---@field order? FrecencyQueryOrder default: "score"
 ---@field record? boolean default: false
----@field workspace? string default: nil
+---@field workspace? string|string[] default: nil
 
 ---@class FrecencyQueryEntry
 ---@field count integer
@@ -223,6 +223,9 @@ function Frecency:query(opts, epoch)
     order = "score",
     record = false,
   }, opts or {})
+  local workspaces = type(opts.workspace) == "table" and opts.workspace
+    or type(opts.workspace) == "string" and { opts.workspace }
+    or nil
   ---@param entry FrecencyDatabaseEntry
   local entries = vim.tbl_map(function(entry)
     return {
@@ -231,7 +234,7 @@ function Frecency:query(opts, epoch)
       score = entry.ages and recency.calculate(entry.count, entry.ages) or 0,
       timestamps = entry.timestamps,
     }
-  end, self.database:get_entries(opts.workspace, epoch))
+  end, self.database:get_entries(workspaces, epoch))
   table.sort(entries, self:query_sorter(opts.order, opts.direction))
   local results = opts.record and entries or vim.tbl_map(function(entry)
     return entry.path


### PR DESCRIPTION
Fix #264

Now you can set multiple directories into each “workspace”.

```lua
workspaces = {
  CONF = "/home/my_username/.config",
  DATA = "/home/my_username/.local/share",
  WIKI = "/home/my_username/wiki",
  PJT = {
    "/home/my_username/project_foo",
    "/home/my_username/project_bar",
    "/home/my_username/project_foobar",
  },
}
```

If you call `:Telescope frecency workspace=CONF`, you can get entries filtered out with the directory (`~/.config`) itself. In case `:Telescope frecency workspace=PJT`, you can get combined results with entries under each directories (`~/project_foo`, `~/project_bar` and `~/project_foobar`).