### PR TITLE
feat!: add an option for mappings in prompt 

### DIFF
--- a/doc/telescope-frecency.txt
+++ b/doc/telescope-frecency.txt
@@ -490,6 +490,16 @@ Type: `boolean`
 
 Disable devicons (if available).
 
+		       *telescope-frecency-configuration-enable_prompt_mappings*
+enable_prompt_mappings ~
+
+Default: `false`
+Type: `boolean`
+
+If enabled, you can start completion for
+|telescope-frecency-introduction-workspace-filter| with `<Tab>` and `<S-Tab>` keys
+succeeded by input `:` (in default).
+
 			  *telescope-frecency-configuration-hide_current_buffer*
 hide_current_buffer ~
 

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -12,6 +12,7 @@ local os_util = require "frecency.os_util"
 ---@field debug_timer? boolean default: false
 ---@field default_workspace? string default: nil
 ---@field disable_devicons? boolean default: false
+---@field enable_prompt_mappings? boolean default: false
 ---@field filter_delimiter? string default: ":"
 ---@field hide_current_buffer? boolean default: false
 ---@field ignore_patterns? string[] default: { "*.git/*", "*/tmp/*", "term://*" }
@@ -43,6 +44,7 @@ local Config = {}
 ---@field debug_timer boolean default: false
 ---@field default_workspace? string default: nil
 ---@field disable_devicons boolean default: false
+---@field enable_prompt_mappings boolean default: false
 ---@field filter_delimiter string default: ":"
 ---@field hide_current_buffer boolean default: false
 ---@field ignore_patterns string[] default: { "*.git/*", "*/tmp/*", "term://*" }
@@ -71,6 +73,7 @@ Config.new = function()
     debug_timer = true,
     default_workspace = true,
     disable_devicons = true,
+    enable_prompt_mappings = true,
     filter_delimiter = true,
     hide_current_buffer = true,
     ignore_patterns = true,
@@ -112,6 +115,7 @@ Config.default_values = {
   debug_timer = false,
   default_workspace = nil,
   disable_devicons = false,
+  enable_prompt_mappings = false,
   filter_delimiter = ":",
   hide_current_buffer = false,
   ignore_patterns = os_util.is_windows and { [[*.git\*]], [[*\tmp\*]], "term://*" }
@@ -173,6 +177,7 @@ Config.setup = function(ext_config)
     debug = { opts.debug, "b" },
     default_workspace = { opts.default_workspace, "s", true },
     disable_devicons = { opts.disable_devicons, "b" },
+    enable_prompt_mappings={opts.enable_prompt_mappings,'b'},
     filter_delimiter = { opts.filter_delimiter, "s" },
     hide_current_buffer = { opts.hide_current_buffer, "b" },
     ignore_patterns = { opts.ignore_patterns, "t" },

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -246,8 +246,10 @@ end
 ---@return nil
 function Picker:set_prompt_options(bufnr)
   vim.bo[bufnr].completefunc = "v:lua.require'telescope'.extensions.frecency.complete"
-  vim.keymap.set("i", "<Tab>", "pumvisible() ? '<C-n>' : '<C-x><C-u>'", { buffer = bufnr, expr = true })
-  vim.keymap.set("i", "<S-Tab>", "pumvisible() ? '<C-p>' : ''", { buffer = bufnr, expr = true })
+  if config.enable_prompt_mappings then
+    vim.keymap.set("i", "<Tab>", "pumvisible() ? '<C-n>' : '<C-x><C-u>'", { buffer = bufnr, expr = true })
+    vim.keymap.set("i", "<S-Tab>", "pumvisible() ? '<C-p>' : ''", { buffer = bufnr, expr = true })
+  end
 end
 
 ---@alias FrecencyFilepathFormatter fun(workspace: string?): fun(filename: string): string, FrecencyTelescopePathStyle[]

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -246,8 +246,6 @@ end
 ---@return nil
 function Picker:set_prompt_options(bufnr)
   vim.bo[bufnr].completefunc = "v:lua.require'telescope'.extensions.frecency.complete"
-  vim.keymap.set("i", "<Tab>", "pumvisible() ? '<C-n>' : '<C-x><C-u>'", { buffer = bufnr, expr = true })
-  vim.keymap.set("i", "<S-Tab>", "pumvisible() ? '<C-p>' : ''", { buffer = bufnr, expr = true })
 end
 
 ---@alias FrecencyFilepathFormatter fun(workspace: string?): fun(filename: string): string, FrecencyTelescopePathStyle[]

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -246,6 +246,8 @@ end
 ---@return nil
 function Picker:set_prompt_options(bufnr)
   vim.bo[bufnr].completefunc = "v:lua.require'telescope'.extensions.frecency.complete"
+  vim.keymap.set("i", "<Tab>", "pumvisible() ? '<C-n>' : '<C-x><C-u>'", { buffer = bufnr, expr = true })
+  vim.keymap.set("i", "<S-Tab>", "pumvisible() ? '<C-p>' : ''", { buffer = bufnr, expr = true })
 end
 
 ---@alias FrecencyFilepathFormatter fun(workspace: string?): fun(filename: string): string, FrecencyTelescopePathStyle[]


### PR DESCRIPTION
Fix #48 

In previous build, you cannot use `<Tab>`/`<S-Tab>` in insert mode in prompt
because these are used to complete workspace filters. This is reported
to be annoying, so I did a breaking change to disable this in default.