### PR TITLE
Check if the buffer is really opened in sorters

### DIFF
--- a/lua/frecency/sorter/opened.lua
+++ b/lua/frecency/sorter/opened.lua
@@ -8,10 +8,12 @@ local Opened = setmetatable({}, { __index = Default })
 ---@return FrecencySorterOpened
 Opened.new = function()
   local self = setmetatable(Default.new(), { __index = Opened }) --[[@as FrecencySorterOpened]]
-  self.buffers = vim.tbl_map(vim.api.nvim_buf_get_name, vim.api.nvim_list_bufs())
+  self.buffers = vim.api.nvim_list_bufs()
   self.buffers_map = {}
-  for _, buffer in ipairs(self.buffers) do
-    self.buffers_map[buffer] = true
+  for _, h in ipairs(self.buffers) do
+    local buffer_name = vim.api.nvim_buf_get_name(h)
+    local is_loaded = vim.api.nvim_buf_is_loaded(h)
+    self.buffers_map[buffer_name] = is_loaded
   end
   return self
 end

--- a/lua/frecency/sorter/same_repo.lua
+++ b/lua/frecency/sorter/same_repo.lua
@@ -9,9 +9,11 @@ local SameRepo = setmetatable({}, { __index = Opened })
 SameRepo.new = function()
   local self = setmetatable(Opened.new(), { __index = SameRepo }) --[[@as FrecencySorterSameRepo]]
   self.repos = {}
-  for _, buf in ipairs(self.buffers) do
-    local repo = vim.fs.root(buf, ".git")
-    if repo then
+  for _, h in ipairs(self.buffers) do
+    local buffer_name = vim.api.nvim_buf_get_name(h)
+    local is_loaded = vim.api.nvim_buf_is_loaded(h)
+    local repo = vim.fs.root(buffer_name, ".git")
+    if repo and is_loaded then
       table.insert(self.repos, repo)
     end
   end

--- a/lua/frecency/tests/sorter_spec.lua
+++ b/lua/frecency/tests/sorter_spec.lua
@@ -67,6 +67,7 @@ describe("frecency.sorter", function()
       local originals = {
         nvim_list_bufs = vim.api.nvim_list_bufs,
         nvim_buf_get_name = vim.api.nvim_buf_get_name,
+        nvim_buf_is_loaded = vim.api.nvim_buf_is_loaded,
         root = vim.fs.root,
       }
       ---@diagnostic disable-next-line: duplicate-set-field
@@ -78,6 +79,10 @@ describe("frecency.sorter", function()
         return ({ "/path/to/project_A/image.jpg", "/path/to/project_B/Makefile" })[bufnr]
       end
       ---@diagnostic disable-next-line: duplicate-set-field
+      vim.api.nvim_buf_is_loaded = function(bufnr)
+        return ({ true, true })[bufnr]
+      end
+      ---@diagnostic disable-next-line: duplicate-set-field
       vim.fs.root = function(path, _)
         return (path:match "(.*project_.)")
       end
@@ -85,6 +90,7 @@ describe("frecency.sorter", function()
       assert.are.same(parse_text(c.entries), sorter:sort(parse_text(entries)))
       vim.api.nvim_list_bufs = originals.nvim_list_bufs
       vim.api.nvim_buf_get_name = originals.nvim_buf_get_name
+      vim.api.nvim_buf_is_loaded = originals.nvim_buf_is_loaded
       vim.fs.root = originals.root
     end)
   end


### PR DESCRIPTION
The check whether the buffer is loaded is added in the enumeration of all the buffers in the list in sorters to ensure the proper sorting.