### PR TITLE
feat: enable to use preferable func for tracking

### DIFF
--- a/doc/telescope-frecency.txt
+++ b/doc/telescope-frecency.txt
@@ -500,6 +500,19 @@ This plugin uses `plenary.log` to log debugging messages. You should set this to
     # see debug messages.
     env DEBUG_PLENARY=1 nvim
 <
+				  *telescope-frecency-configuration-debug_timer*
+debug_timer ~
+
+Default: `false`
+Type: `boolean|fun(event: string): nil`
+
+If `debug == true` and this variable seems truthy, it starts to call a function
+to track its activities. In default, it uses `require("lazy.stats").track()` if
+available. You can specify your own function to do this by setting here.
+
+See detail demo in this PR below.
+https://github.com/nvim-telescope/telescope-frecency.nvim/pull/282
+
 			    *telescope-frecency-configuration-default_workspace*
 default_workspace ~
 

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -9,7 +9,7 @@ local os_util = require "frecency.os_util"
 ---@field db_safe_mode? boolean default: true
 ---@field db_validate_threshold? integer default: 10
 ---@field debug? boolean default: false
----@field debug_timer? boolean default: false
+---@field debug_timer? boolean|fun(event: string): nil default: false
 ---@field default_workspace? string default: nil
 ---@field disable_devicons? boolean default: false
 ---@field enable_prompt_mappings? boolean default: false
@@ -42,7 +42,7 @@ local Config = {}
 ---@field db_safe_mode boolean default: true
 ---@field db_validate_threshold integer default: 10
 ---@field debug boolean default: false
----@field debug_timer boolean default: false
+---@field debug_timer boolean|fun(event: string): nil default: false
 ---@field default_workspace? string default: nil
 ---@field disable_devicons boolean default: false
 ---@field enable_prompt_mappings boolean default: false
@@ -181,6 +181,7 @@ Config.setup = function(ext_config)
     vim.validate("db_safe_mode", opts.db_safe_mode, "boolean")
     vim.validate("db_validate_threshold", opts.db_validate_threshold, "number")
     vim.validate("debug", opts.debug, "boolean")
+    vim.validate("debug_timer", opts.debug_timer, { "boolean", "function" })
     vim.validate("default_workspace", opts.default_workspace, "string", true)
     vim.validate("disable_devicons", opts.disable_devicons, "boolean")
     vim.validate("enable_prompt_mappings", opts.enable_prompt_mappings, "boolean")
@@ -211,6 +212,7 @@ Config.setup = function(ext_config)
       db_safe_mode = { opts.db_safe_mode, "b" },
       db_validate_threshold = { opts.db_validate_threshold, "n" },
       debug = { opts.debug, "b" },
+      debug_timer = { opts.debug, { "b", "f" } },
       default_workspace = { opts.default_workspace, "s", true },
       disable_devicons = { opts.disable_devicons, "b" },
       enable_prompt_mappings = { opts.enable_prompt_mappings, "b" },


### PR DESCRIPTION
This makes `debug_timer` accept a function for tracking. This shows times with tracking messages as below, with my example class.

https://github.com/delphinus/dotfiles/blob/fd4542a648bfb49f47c85437d9ce42cbec9a3f48/.config/nvim/lua/core/utils/timer.lua

```lua
-- shows tracked times
require("core.utils.timer").pp()
```

<img width="415" alt="スクリーンショット 2025-01-03 午後9 16 11" src="https://github.com/user-attachments/assets/f5e02c14-7135-4afa-90ee-2739d595b597" />