### PR TITLE
fix: detect `show_filter_column: false` validly

### DIFF
--- a/lua/frecency/entry_maker.lua
+++ b/lua/frecency/entry_maker.lua
@@ -167,6 +167,9 @@ end
 ---@return boolean
 function EntryMaker.should_show_tail(_, workspace_tag)
   local show_filter_column = config.show_filter_column
+  if show_filter_column == false then
+    return false
+  end
   local filters = type(show_filter_column) == "table" and show_filter_column or { "LSP", "CWD" }
   return vim.list_contains(filters, workspace_tag)
 end


### PR DESCRIPTION
Fix #289

In the former build, it has ignored `false` value for `show_filter_column`, so always shown the workspace filter name. This fixes this.