### PR TITLE
fix: show incorrect default icon 

### DIFF
--- a/lua/frecency/web_devicons.lua
+++ b/lua/frecency/web_devicons.lua
@@ -6,11 +6,11 @@ local M = {
   ---@return string
   ---@return string
   get_icon = function(name, ext, opts)
-    local ok, web_devicons = pcall(require, "nvim-web-devicons", opts)
+    local ok, web_devicons = pcall(require, "nvim-web-devicons")
     if not ok then
       return "", ""
     end
-    return web_devicons.get_icon(name, ext)
+    return web_devicons.get_icon(name, ext, opts)
   end,
 }
 


### PR DESCRIPTION
| Current | Updated |
|--------|--------|
| <img width="275" alt="Screenshot 2025-01-09 at 12 39 57" src="https://github.com/user-attachments/assets/406041cf-f8f7-415d-a110-caf5a1c5d331" /> | <img width="275" alt="Screenshot 2025-01-09 at 12 39 37" src="https://github.com/user-attachments/assets/67f30738-c402-4afa-a2b2-6639699f564a" /> | 

Let's consider the `run-tests` entry.

Currently, we have an `n...` icon because we didn't pass `opts` to `nvim-web-devicons` correctly
