### PR TITLE
fix: do not remove ignored entries

### DIFF
--- a/lua/frecency/v1/database.lua
+++ b/lua/frecency/v1/database.lua
@@ -114,7 +114,7 @@ function DatabaseV1:unlinked_entries()
     :map(function(path, _)
       return function()
         local err, realpath = async.uv.fs_realpath(path)
-        if err or not realpath or realpath ~= path or fs.is_ignored(realpath) then
+        if err or not realpath or realpath ~= path then
           return path
         end
       end


### PR DESCRIPTION
When the `ignore_patterns` option is changed, it mistakenly treats ignored entries as “unlinked”, and removes them from DB. This is not an intended behavior. This fixes it.