### PR TITLE
feat: unregister hidden or unloaded buffers

### DIFF
--- a/doc/telescope-frecency.txt
+++ b/doc/telescope-frecency.txt
@@ -760,6 +760,20 @@ Type: `boolean`
 
 Determines if non-indexed files are included in workspace filter results.
 
+			    *telescope-frecency-configuration-unregister_hidden*
+unregister_hidden ~
+
+Default: `false`
+Type: `boolean`
+
+If `false` (default value), this plugin marks the file as “registered” when it
+is opened, so the file's frecency score will not be increased when the buffer
+is shown again until Neovim restarts.
+
+If `true`, it marks the buffer as “unregistered” when it becomes a |hidden-buffer|
+or an |inactive-buffer|. Then it will increase the buffer's score when it
+becomes an |active-buffer| that means it is shown in another window again.
+
 			   *telescope-frecency-configuration-workspace_scan_cmd*
 workspace_scan_cmd ~
 

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -26,6 +26,7 @@ local os_util = require "frecency.os_util"
 ---@field show_filter_column? boolean|string[] default: true
 ---@field show_scores? boolean default: false
 ---@field show_unindexed? boolean default: true
+---@field unregister_hidden? boolean default: false
 ---@field workspace_scan_cmd? "LUA"|string[] default: nil
 ---@field workspaces? table<string, string|string[]> default: {}
 
@@ -60,6 +61,7 @@ local Config = {}
 ---@field show_filter_column boolean|string[] default: true
 ---@field show_scores boolean default: false
 ---@field show_unindexed boolean default: true
+---@field unregister_hidden boolean default: false
 ---@field workspace_scan_cmd? "LUA"|string[] default: nil
 ---@field workspaces table<string, string|string[]> default: {}
 
@@ -91,6 +93,7 @@ Config.new = function()
     show_filter_column = true,
     show_scores = true,
     show_unindexed = true,
+    unregister_hidden = true,
     workspace_scan_cmd = true,
     workspaces = true,
   }
@@ -148,6 +151,7 @@ Config.default_values = {
   show_filter_column = true,
   show_scores = false,
   show_unindexed = true,
+  unregister_hidden = false,
   workspace_scan_cmd = nil,
   workspaces = {},
 }
@@ -207,6 +211,7 @@ Config.setup = function(ext_config)
     vim.validate("show_filter_column", opts.show_filter_column, { "boolean", "table" }, true)
     vim.validate("show_scores", opts.show_scores, "boolean")
     vim.validate("show_unindexed", opts.show_unindexed, "boolean")
+    vim.validate("unregister_hidden", opts.unregister_hidden, "boolean")
     vim.validate("workspace_scan_cmd", opts.workspace_scan_cmd, { "string", "table" }, true)
     vim.validate("workspaces", opts.workspaces, "table")
   else
@@ -257,6 +262,7 @@ Config.setup = function(ext_config)
       show_filter_column = { opts.show_filter_column, { "b", "t" }, true },
       show_scores = { opts.show_scores, "b" },
       show_unindexed = { opts.show_unindexed, "b" },
+      unregister_hidden = { opts.unregister_hidden, "b" },
       workspace_scan_cmd = { opts.workspace_scan_cmd, { "s", "t" }, true },
       workspaces = { opts.workspaces, "t" },
     }

--- a/lua/frecency/init.lua
+++ b/lua/frecency/init.lua
@@ -10,6 +10,7 @@ local database
 ---@field query fun(opts?: FrecencyQueryOpts): FrecencyQueryEntry[]|string[]
 ---@field register async fun(bufnr: integer, datetime: string?): nil
 ---@field start fun(opts: FrecencyPickerOptions?): nil
+---@field unregister fun(bufnr: integer): nil
 ---@field validate_database async fun(force: boolean?): nil
 local frecency = setmetatable({}, {
   ---@param self FrecencyInstance
@@ -90,6 +91,16 @@ local function setup(ext_config)
       async_call(frecency.register, args.buf, vim.api.nvim_buf_get_name(args.buf))
     end,
   })
+
+  if config.unregister_hidden then
+    vim.api.nvim_create_autocmd({ "BufHidden", "BufUnload" }, {
+      desc = "Unregister in hiding buffers for telescope-frecency",
+      group = group,
+      callback = function(args)
+        frecency.unregister(args.buf)
+      end,
+    })
+  end
 
   if config.bootstrap and vim.v.vim_did_enter == 0 then
     database = require("frecency.database").create(config.db_version)

--- a/lua/frecency/klass.lua
+++ b/lua/frecency/klass.lua
@@ -183,6 +183,12 @@ function Frecency:register(bufnr, path, epoch)
   log.debug("registered:", bufnr, path)
 end
 
+---@param bufnr integer
+---@return nil
+function Frecency:unregister(bufnr)
+  self.buf_registered[bufnr] = nil
+end
+
 ---@async
 ---@param path string
 ---@return nil


### PR DESCRIPTION
Fix #236

When the buffer is hidden or unloaded, this plugin marks it “unregistered” and will register again in showing the buffer (in `BufWinEnter` event). This increases the buffer's frecency score in DB.

In default, this is disabled (current at least). You can enable this with `unregister_hidden = true` in config.