### PR TITLE
fix: filter with config.ignore_patterns in listing

### DIFF
--- a/lua/frecency/v1/database.lua
+++ b/lua/frecency/v1/database.lua
@@ -156,10 +156,13 @@ function DatabaseV1:get_entries(workspaces, epoch)
   return vim
     .iter(self.tbl:records())
     :filter(function(path, _)
-      return not workspaces
-        or vim.iter(workspaces):any(function(workspace)
-          return fs.starts_with(path, workspace)
-        end)
+      return not fs.is_ignored(path)
+        and (
+          not workspaces
+          or vim.iter(workspaces):any(function(workspace)
+            return fs.starts_with(path, workspace)
+          end)
+        )
     end)
     :map(function(path, record)
       return EntryV1.new(path, record, now)

--- a/lua/frecency/v2/database.lua
+++ b/lua/frecency/v2/database.lua
@@ -77,10 +77,13 @@ function DatabaseV2:get_entries(workspaces, epoch)
   return vim
     .iter(self.tbl:records())
     :filter(function(path, _)
-      return not workspaces
-        or vim.iter(workspaces):any(function(workspace)
-          return fs.starts_with(path, workspace)
-        end)
+      return not fs.is_ignored(path)
+        and (
+          not workspaces
+          or vim.iter(workspaces):any(function(workspace)
+            return fs.starts_with(path, workspace)
+          end)
+        )
     end)
     :map(function(path, _)
       return self.tbl:entry(path, now)


### PR DESCRIPTION
I've noticed `config.ignore_patterns` is only affected in registering and it does not ignore in getting entries. This fixes it.