### PR TITLE
fix: enable ignore_patterns for fd / rg

### DIFF
--- a/lua/frecency/finder.lua
+++ b/lua/frecency/finder.lua
@@ -41,6 +41,13 @@ local Finder = {
           return pcall(vim.system, { candidate[1], "--version" })
         end)
       end
+      vim.iter(config.ignore_patterns):each(cache[1] == "rg" and function(v)
+        table.insert(cache, "-g")
+        table.insert(cache, "!" .. v)
+      end or function(v)
+        table.insert(cache, "-E")
+        table.insert(cache, v)
+      end)
       return cache
     end
   end)(),


### PR DESCRIPTION
At previous builds, config.ignore_patterns was used only for LUA logic. With this, frecency uses them in listing by `fd`/`rg` commands.