### PR TITLE
filter out deleted file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ luac.out
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -93,3 +94,4 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+.aider*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+telescope-frecency.nvim is a Neovim Telescope extension implementing Mozilla's Frecency algorithm for intelligent file prioritization.
+
+## Build/Test Commands
+- Run all tests: `bin/run-tests`
+- Run specific test: `bin/run-tests lua/frecency/tests/test_file.lua`
+- Run with verbose logs: `bin/run-tests -v`
+- Use custom Neovim binary: `bin/run-tests -e /path/to/nvim`
+
+## Code Style
+- Language: Lua
+- Indentation: 2 spaces
+- Typing: Use LuaLS annotations (---@class, ---@param, etc.)
+- Naming: snake_case for variables/functions
+- Error handling: Check errors with assertions
+- Documentation: Docstrings for public functions
+- Async patterns: Use async/await with plenary.async
+- Testing: Test files in lua/frecency/tests/ with *_spec.lua suffix
+- Imports: Standard Lua require statements
+- Type validation: Use vim.validate for config validation

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -19,6 +19,7 @@ local os_util = require "frecency.os_util"
 ---@field ignore_patterns? string[] default: { "*.git/*", "*/tmp/*", "term://*" }
 ---@field ignore_register? fun(bufnr: integer): boolean
 ---@field matcher? "default"|"fuzzy" default: "default"
+---@field remove_non_existent_files? boolean default: true
 ---@field scoring_function? fun(recency: integer, fzy_score: number): number default: see lua/frecency/config.lua
 ---@field max_timestamps? integer default: 10
 ---@field path_display? table default: nil
@@ -54,6 +55,7 @@ local Config = {}
 ---@field ignore_patterns string[] default: { "*.git/*", "*/tmp/*", "term://*" }
 ---@field ignore_register? fun(bufnr: integer): boolean default: nil
 ---@field matcher "default"|"fuzzy" default: "default"
+---@field remove_non_existent_files boolean default: true
 ---@field scoring_function fun(recency: integer, fzy_score: number): number default: see lua/frecency/config.lua
 ---@field max_timestamps integer default: 10
 ---@field path_display? table default: nil
@@ -89,6 +91,7 @@ Config.new = function()
     max_timestamps = true,
     path_display = true,
     preceding = true,
+    remove_non_existent_files = true,
     scoring_function = true,
     show_filter_column = true,
     show_scores = true,
@@ -132,6 +135,7 @@ Config.default_values = {
     or { "*.git/*", "*/tmp/*", "term://*" },
   matcher = "default",
   max_timestamps = 10,
+  remove_non_existent_files = true,
   recency_values = {
     { age = 240, value = 100 }, -- past 4 hours
     { age = 1440, value = 80 }, -- past day
@@ -208,6 +212,7 @@ Config.setup = function(ext_config)
     vim.validate("preceding", opts.preceding, function(v)
       return v == "opened" or v == "same_repo" or v == nil
     end, '"opened" or "same_repo" or nil')
+    vim.validate("remove_non_existent_files", opts.remove_non_existent_files, "boolean", true)
     vim.validate("show_filter_column", opts.show_filter_column, { "boolean", "table" }, true)
     vim.validate("show_scores", opts.show_scores, "boolean")
     vim.validate("show_unindexed", opts.show_unindexed, "boolean")
@@ -261,6 +266,7 @@ Config.setup = function(ext_config)
         end,
         '"opened" or "same_repo" or nil',
       },
+      remove_non_existent_files = { opts.remove_non_existent_files, "b", true },
       show_filter_column = { opts.show_filter_column, { "b", "t" }, true },
       show_scores = { opts.show_scores, "b" },
       show_unindexed = { opts.show_unindexed, "b" },

--- a/lua/frecency/klass.lua
+++ b/lua/frecency/klass.lua
@@ -52,11 +52,18 @@ function Frecency:setup(is_async, need_cleanup)
     end
     if self.status == STATUS.DB_STARTED and need_cleanup then
       self:assert_db_entries()
-      if config.auto_validate then
-        self:validate_database()
-      end
       self.status = STATUS.CLEANUP_FINISHED
       timer.track "CLEANUP_FINISHED"
+      if config.auto_validate then
+        -- Defer validation so it doesn't open a nested vim.ui.select picker
+        -- during the same tick that the frecency picker is being opened,
+        -- which would leave stray input in the prompt buffer.
+        vim.schedule(function()
+          async.void(function()
+            self:validate_database()
+          end)()
+        end)
+      end
     end
     timer.track "frecency.setup() finish"
   end


### PR DESCRIPTION
When files are deleted, they are stuck in the DB and still show up in telescope. This change fixed that by tracking if a file exists before displaying it, and asynchronously removing all selectable but deleted files from the database later. This might cause performance issues, but on my Apple M4 Max, even running `require('telescope').extensions.frecency.frecency({ workspace = "CWD" })` on home directory with 64K recursive files, it seems to run smoothly. Nonetheless, I added a flag to disable this behavior if needed. 