### PR TITLE
feat: detect file_ignore_patterns from telescope

### DIFF
--- a/doc/telescope-frecency.txt
+++ b/doc/telescope-frecency.txt
@@ -564,6 +564,26 @@ If enabled, you can start completion for
 |telescope-frecency-introduction-workspace-filter| with `<Tab>` and `<S-Tab>` keys
 succeeded by input `:` (in default).
 
+			 *telescope-frecency-configuration-file_ignore_patterns*
+file_ignore_patterns ~
+
+Default: `nil`
+Type: `table`
+
+Like |telescope.defaults.file_ignore_patterns|, this is a table of lua regex and
+will be used to filter out results from not only the frecency picker but also
+|telescope-frecency-function-query|.
+
+NOTE: See also |telescope-frecency-configuration-ignore_patterns|.
+
+			     *telescope-frecency-configuration-filter_delimiter*
+filter_delimiter ~
+
+Default: `":"`
+Type: `string`
+
+Delimiters to indicate the filter like `:CWD:`.
+
 			  *telescope-frecency-configuration-hide_current_buffer*
 hide_current_buffer ~
 
@@ -571,11 +591,6 @@ Default: `false`
 Type: `boolean`
 
 If `true`, it does not show the filename in the current buffer in candidates.
-
-			     *telescope-frecency-configuration-filter_delimiter*
-filter_delimiter ~
-
-Delimiters to indicate the filter like `:CWD:`.
 
 			      *telescope-frecency-configuration-ignore_patterns*
 ignore_patterns ~
@@ -590,6 +605,8 @@ which you'll see in the finder results).
 
 NOTE: In registering, |telescope-frecency-configuration-ignore_register| is
 applied before this patterns
+
+NOTE: See also |telescope-frecency-configuration-file_ignore_patterns|.
 
 			      *telescope-frecency-configuration-ignore_register*
 ignore_register ~

--- a/lua/frecency/config.lua
+++ b/lua/frecency/config.lua
@@ -14,6 +14,7 @@ local os_util = require "frecency.os_util"
 ---@field default_workspace? string default: nil
 ---@field disable_devicons? boolean default: false
 ---@field enable_prompt_mappings? boolean default: false
+---@field file_ignore_patterns? string[]? default: nil
 ---@field filter_delimiter? string default: ":"
 ---@field hide_current_buffer? boolean default: false
 ---@field ignore_patterns? string[] default: { "*.git/*", "*/tmp/*", "term://*" }
@@ -49,6 +50,7 @@ local Config = {}
 ---@field default_workspace? string default: nil
 ---@field disable_devicons boolean default: false
 ---@field enable_prompt_mappings boolean default: false
+---@field file_ignore_patterns string[]? default: nil
 ---@field filter_delimiter string default: ":"
 ---@field hide_current_buffer boolean default: false
 ---@field ignore_patterns string[] default: { "*.git/*", "*/tmp/*", "term://*" }
@@ -81,6 +83,7 @@ Config.new = function()
     default_workspace = true,
     disable_devicons = true,
     enable_prompt_mappings = true,
+    file_ignore_patterns = true,
     filter_delimiter = true,
     hide_current_buffer = true,
     ignore_patterns = true,
@@ -126,6 +129,7 @@ Config.default_values = {
   default_workspace = nil,
   disable_devicons = false,
   enable_prompt_mappings = false,
+  file_ignore_patterns = nil,
   filter_delimiter = ":",
   hide_current_buffer = false,
   ignore_patterns = os_util.is_windows and { [[*.git\*]], [[*\tmp\*]], "term://*" }
@@ -196,6 +200,7 @@ Config.setup = function(ext_config)
     vim.validate("default_workspace", opts.default_workspace, "string", true)
     vim.validate("disable_devicons", opts.disable_devicons, "boolean")
     vim.validate("enable_prompt_mappings", opts.enable_prompt_mappings, "boolean")
+    vim.validate("file_ignore_patterns", opts.file_ignore_patterns, "table", true)
     vim.validate("filter_delimiter", opts.filter_delimiter, "string")
     vim.validate("hide_current_buffer", opts.hide_current_buffer, "boolean")
     vim.validate("ignore_patterns", opts.ignore_patterns, "table")
@@ -237,6 +242,7 @@ Config.setup = function(ext_config)
       default_workspace = { opts.default_workspace, "s", true },
       disable_devicons = { opts.disable_devicons, "b" },
       enable_prompt_mappings = { opts.enable_prompt_mappings, "b" },
+      file_ignore_patterns = { opts.file_ignore_patterns, "t", true },
       filter_delimiter = { opts.filter_delimiter, "s" },
       hide_current_buffer = { opts.hide_current_buffer, "b" },
       ignore_patterns = { opts.ignore_patterns, "t" },


### PR DESCRIPTION
Ref #108

Previously, it ignores `file_ignore_patterns` from telescope.config and also it is very confusing with `ignore_patterns` (#108).

This commit enables it detect `file_ignore_patterns` in both the picker and `frecency.query()`, and adds doc for it.