### PR TITLE
refactor: remove obsolete vim.loop shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,19 @@
 name: CI
+
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  workflow_dispatch:
+
 jobs:
   test:
     name: Run tests
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -13,12 +21,12 @@ jobs:
           - windows-latest
         version:
           - v0.10.4
-          - v0.11.4
+          - stable
           - nightly
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Neovim
         uses: rhysd/action-setup-vim@v1
         id: nvim

--- a/lua/frecency/fs.lua
+++ b/lua/frecency/fs.lua
@@ -5,11 +5,10 @@ local lazy_require = require "frecency.lazy_require"
 local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
 local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 local scandir = lazy_require "plenary.scandir"
-local uv = vim.uv or vim.loop
 
 ---@class FrecencyFS
 local M = {
-  os_homedir = assert(uv.os_homedir()),
+  os_homedir = assert(vim.uv.os_homedir()),
 }
 
 -- TODO: make this configurable

--- a/lua/frecency/os_util.lua
+++ b/lua/frecency/os_util.lua
@@ -1,10 +1,9 @@
 local lazy_require = require "frecency.lazy_require"
 local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
-local uv = vim.uv or vim.loop
 
 ---@class FrecencyOSUtil
 local M = {
-  is_windows = uv.os_uname().sysname == "Windows_NT",
+  is_windows = vim.uv.os_uname().sysname == "Windows_NT",
 }
 
 ---@type fun(filename: string): string

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -11,7 +11,6 @@ local actions = lazy_require "telescope.actions"
 local telescope_config = lazy_require "telescope.config"
 local pickers = lazy_require "telescope.pickers"
 local utils = lazy_require "telescope.utils" --[[@as FrecencyTelescopeUtils]]
-local uv = vim.loop or vim.uv
 
 ---@class FrecencyPicker
 ---@field private config FrecencyPickerConfig
@@ -85,7 +84,7 @@ end
 ---@param opts? FrecencyPickerOptions
 function Picker:start(opts)
   opts = vim.tbl_extend("force", {
-    cwd = uv.cwd(),
+    cwd = vim.uv.cwd(),
     path_display = function(picker_opts, path)
       return self:default_path_display(picker_opts, path)
     end,

--- a/lua/frecency/tests/util.lua
+++ b/lua/frecency/tests/util.lua
@@ -2,7 +2,6 @@
 local Frecency = require "frecency.klass"
 local Picker = require "frecency.picker"
 local config = require "frecency.config"
-local uv = vim.uv or vim.loop
 local log = require "plenary.log"
 local async = require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 local Path = require "plenary.path"
@@ -12,17 +11,17 @@ local wait = require "frecency.wait"
 ---@return FrecencyPlenaryPath
 ---@return fun(): nil close swwp all entries
 local function tmpdir()
-  local ci = uv.os_getenv "CI"
+  local ci = vim.uv.os_getenv "CI"
   local dir
   if ci then
-    dir = Path:new(assert(uv.fs_mkdtemp "tests_XXXXXX"))
+    dir = Path:new(assert(vim.uv.fs_mkdtemp "tests_XXXXXX"))
   else
-    local tmp = assert(uv.os_tmpdir())
+    local tmp = assert(vim.uv.os_tmpdir())
     -- HACK: plenary.path resolves paths later, so here it resolves in advance.
-    if uv.os_uname().sysname == "Darwin" then
+    if vim.uv.os_uname().sysname == "Darwin" then
       tmp = tmp:gsub("^/var", "/private/var")
     end
-    dir = Path:new(assert(uv.fs_mkdtemp(Path:new(tmp, "tests_XXXXXX").filename)))
+    dir = Path:new(assert(vim.uv.fs_mkdtemp(Path:new(tmp, "tests_XXXXXX").filename)))
   end
   return dir, function()
     dir:rm { recursive = true }

--- a/lua/frecency/watcher.lua
+++ b/lua/frecency/watcher.lua
@@ -1,7 +1,6 @@
 local log = require "frecency.log"
 local lazy_require = require "frecency.lazy_require"
 local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
-local uv = vim.loop or vim.uv
 
 ---@class FrecencyWatcherMtime
 ---@field sec integer
@@ -42,7 +41,7 @@ function Watcher:watch(path, cb)
   if self.handler then
     self.handler:stop()
   end
-  self.handler = assert(uv.new_fs_event()) --[[@as UvFsEventHandle]]
+  self.handler = assert(vim.uv.new_fs_event()) --[[@as UvFsEventHandle]]
   self.handler:start(path, { recursive = true }, function(err, _, _)
     if err then
       log.debug("failed to watch path: " .. err)


### PR DESCRIPTION
No longer needed now that support for Nvim 0.10 is dropped.

(Also, it was the wrong way around ;))