### PR TITLE
fix: add shim for deprecated `vim.F.npcall`

### DIFF
--- a/lua/frecency/v1/database.lua
+++ b/lua/frecency/v1/database.lua
@@ -10,6 +10,9 @@ local lazy_require = require "frecency.lazy_require"
 local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
 
+-- todo(clason): remove when dropping support for Nvim 0.12
+local npcall = vim.npcall or vim.F.npcall
+
 ---@class FrecencyDatabaseV1: FrecencyDatabase
 ---@field protected tbl FrecencyTableV1
 local DatabaseV1 = {}
@@ -200,8 +203,8 @@ function DatabaseV1:_load(file_lock, update_watcher) -- luacheck: no self
     return data
   end)
   assert(not err, err)
-  local f = vim.F.npcall(loadstring, data or "")
-  return f and vim.F.npcall(f)
+  local f = npcall(loadstring, data or "")
+  return f and npcall(f)
 end
 
 ---@async

--- a/lua/telescope/_extensions/frecency.lua
+++ b/lua/telescope/_extensions/frecency.lua
@@ -13,7 +13,7 @@ return require("telescope").register_extension {
     else
       vim.health.error "Neovim version must be 0.10 or higher."
     end
-    if vim.F.npcall(require, "nvim-web-devicons") then
+    if pcall(require, "nvim-web-devicons") then
       vim.health.ok "nvim-web-devicons installed."
     else
       vim.health.info "nvim-web-devicons is not installed."


### PR DESCRIPTION
@delphinus is `npcall` even needed here? can we replace one or both with `pcall`?