### PR TITLE
refactor: drop plenary.path and plenary.scandir from production code (PR3 of plenary removal)

### DIFF
--- a/lua/frecency/entry_maker.lua
+++ b/lua/frecency/entry_maker.lua
@@ -1,7 +1,7 @@
 local web_devicons = require "frecency.web_devicons"
 local config = require "frecency.config"
 local fs = require "frecency.fs"
-local Path = require "plenary.path"
+local os_util = require "frecency.os_util"
 local lazy_require = require "frecency.lazy_require"
 local entry_display = lazy_require "telescope.pickers.entry_display" --[[@as FrecencyTelescopeEntryDisplay]]
 local utils = lazy_require "telescope.utils" --[[@as FrecencyTelescopeUtils]]
@@ -35,7 +35,7 @@ function EntryMaker:create(filepath_formatter, workspaces, workspace_tag)
   -- in entry_maker because it will be called in a Lua loop.
   local displayer = entry_display.create {
     separator = "",
-    hl_chars = { [Path.path.sep] = "TelescopePathSeparator" },
+    hl_chars = { [os_util.sep] = "TelescopePathSeparator" },
     items = self:width_items(workspaces, workspace_tag),
   }
 
@@ -129,8 +129,8 @@ function EntryMaker:items(entry, workspace, workspace_tag, formatter)
     table.insert(items, { icon, icon_highlight })
   end
   if config.show_filter_column and workspace and workspace_tag then
-    local filtered = self:should_show_tail(workspace_tag) and utils.path_tail(workspace) .. Path.path.sep
-      or fs.relative_from_home(workspace) .. Path.path.sep
+    local filtered = self:should_show_tail(workspace_tag) and utils.path_tail(workspace) .. os_util.sep
+      or fs.relative_from_home(workspace) .. os_util.sep
     table.insert(items, { filtered, "Directory" })
   end
   local formatted_name, path_style = formatter(entry.name)

--- a/lua/frecency/file_lock.lua
+++ b/lua/frecency/file_lock.lua
@@ -1,6 +1,5 @@
 local log = require "frecency.log"
 local lazy_require = require "frecency.lazy_require"
-local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
 local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
 
 ---@class FrecencyFileLock
@@ -37,12 +36,11 @@ function FileLock:get()
   local err, fd
   while true do
     count = count + 1
-    local dir = Path.new(self.lock):parent()
-    if not dir:exists() then
+    local dir = vim.fs.dirname(self.lock)
+    if not vim.uv.fs_stat(dir) then
       -- TODO: make this call be async
-      log.debug(("file_lock get(): mkdir parent: %s"):format(dir.filename))
-      ---@diagnostic disable-next-line: undefined-field
-      dir:mkdir { parents = true }
+      log.debug(("file_lock get(): mkdir parent: %s"):format(dir))
+      vim.fn.mkdir(dir, "p")
     end
     err, fd = async.uv.fs_open(self.lock, "wx", tonumber("600", 8))
     if not err then

--- a/lua/frecency/fs.lua
+++ b/lua/frecency/fs.lua
@@ -2,9 +2,7 @@ local config = require "frecency.config"
 local os_util = require "frecency.os_util"
 local log = require "frecency.log"
 local lazy_require = require "frecency.lazy_require"
-local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
 local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
-local scandir = lazy_require "plenary.scandir"
 
 ---@class FrecencyFS
 local M = {
@@ -60,7 +58,7 @@ end
 ---@param path string
 ---@return string
 function M.relative_from_home(path)
-  return Path:new(path):make_relative(M.os_homedir)
+  return vim.fs.relpath(M.os_homedir, path) or path
 end
 
 ---@type table<string,string>
@@ -74,7 +72,7 @@ function M.starts_with(path, base)
     return true
   end
   if not with_sep[base] then
-    with_sep[base] = base .. (base:sub(#base) == Path.path.sep and "" or Path.path.sep)
+    with_sep[base] = base .. (base:sub(#base) == os_util.sep and "" or os_util.sep)
   end
   return path:find(with_sep[base], 1, true) == 1
 end
@@ -86,11 +84,70 @@ function M.exists(path)
   return not (async.uv.fs_stat(path))
 end
 
+-- Vendored from plenary.scandir.__make_gitignore (the only function this plugin
+-- used from plenary.scandir). Returns a filter `(base_paths, entry) -> boolean`
+-- that returns false when `entry` matches a .gitignore rule under one of the
+-- base paths. Returns a permissive filter when no .gitignore is found.
 ---@private
 ---@param basepath string
 ---@return fun(base_paths: string[], entry: string): boolean
 function M.make_gitignore(basepath)
-  return scandir.__make_gitignore { basepath } or function(_, _)
+  local basepaths = { basepath }
+  local patterns = {}
+  local valid = false
+  for _, v in ipairs(basepaths) do
+    local gitignore = v .. os_util.sep .. ".gitignore"
+    if vim.uv.fs_stat(gitignore) then
+      valid = true
+      patterns[v] = { ignored = {}, negated = {} }
+      for l in io.lines(gitignore) do
+        local prefix = l:sub(1, 1)
+        local negated = prefix == "!"
+        if negated then
+          l = l:sub(2)
+          prefix = l:sub(1, 1)
+        end
+        if prefix == "/" then
+          l = v .. l
+        end
+        if not (prefix == "" or prefix == "#") then
+          local el = vim.trim(l)
+          el = el:gsub("%-", "%%-")
+          el = el:gsub("%.", "%%.")
+          el = el:gsub("/%*%*/", "/%%w+/")
+          el = el:gsub("%*%*", "")
+          el = el:gsub("%*", "%%w+")
+          el = el:gsub("%?", "%%w")
+          if el ~= "" then
+            table.insert(negated and patterns[v].negated or patterns[v].ignored, el)
+          end
+        end
+      end
+    end
+  end
+  if not valid then
+    return function(_, _)
+      return true
+    end
+  end
+  return function(bp, entry)
+    for _, v in ipairs(bp) do
+      if entry:find(v, 1, true) then
+        local negated = false
+        for _, w in ipairs(patterns[v].ignored) do
+          if not negated and entry:match(w) then
+            for _, inverse in ipairs(patterns[v].negated) do
+              if not negated and entry:match(inverse) then
+                negated = true
+              end
+            end
+            if not negated then
+              return false
+            end
+          end
+        end
+      end
+    end
     return true
   end
 end

--- a/lua/frecency/os_util.lua
+++ b/lua/frecency/os_util.lua
@@ -1,10 +1,9 @@
-local lazy_require = require "frecency.lazy_require"
-local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
-
 ---@class FrecencyOSUtil
 local M = {
   is_windows = vim.uv.os_uname().sysname == "Windows_NT",
 }
+
+M.sep = M.is_windows and "\\" or "/"
 
 ---@type fun(filename: string): string
 M.normalize_sep = M.is_windows
@@ -12,20 +11,21 @@ M.normalize_sep = M.is_windows
       if not filename:find("/", 1, true) or filename:match "^%a+://" then
         return filename
       end
-      local replaced = filename:gsub("/", Path.path.sep)
+      local replaced = filename:gsub("/", "\\")
       return replaced
     end
   or function(filename)
     return filename
   end
 
---- Join path segments into a single path string.
---- NOTE: Do not use vim.fs.joinpath because it does not work on Windows.
+-- vim.fs.joinpath always uses "/", so on Windows we normalize separators to "\"
+-- to keep paths consistent with the rest of the codebase (which compares paths
+-- with starts_with and stores them in the on-disk database).
 ---@type fun(...: string): string
 M.join_path = M.is_windows and function(...)
-  return M.normalize_sep(Path:new(...).filename)
+  return M.normalize_sep(vim.fs.joinpath(...))
 end or function(...)
-  return Path:new(...).filename
+  return vim.fs.joinpath(...)
 end
 
 return M

--- a/lua/frecency/picker.lua
+++ b/lua/frecency/picker.lua
@@ -4,9 +4,9 @@ local Finder = require "frecency.finder"
 local config = require "frecency.config"
 local fs = require "frecency.fs"
 local fuzzy_matcher = require "frecency.fuzzy_matcher"
+local os_util = require "frecency.os_util"
 local substr_matcher = require "frecency.substr_matcher"
 local lazy_require = require "frecency.lazy_require"
-local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
 local actions = lazy_require "telescope.actions"
 local telescope_config = lazy_require "telescope.config"
 local pickers = lazy_require "telescope.pickers"
@@ -151,12 +151,12 @@ end
 ---@param path string
 ---@return string
 function Picker:default_path_display(opts, path)
-  local filename = Path:new(path):make_relative(opts.cwd)
+  local filename = vim.fs.relpath(opts.cwd, path) or path
   if not self.workspaces or #self.workspaces == 0 then
     if vim.startswith(filename, fs.os_homedir) then
-      filename = "~" .. Path.path.sep .. fs.relative_from_home(filename)
+      filename = "~" .. os_util.sep .. fs.relative_from_home(filename)
     elseif filename ~= path then
-      filename = "." .. Path.path.sep .. filename
+      filename = "." .. os_util.sep .. filename
     end
   end
   return filename

--- a/lua/frecency/types.lua
+++ b/lua/frecency/types.lua
@@ -33,18 +33,6 @@
 ---@field rm fun(self: FrecencyPlenaryPath, opts?: { recursive: boolean }): nil
 ---@field touch fun(self: FrecencyPlenaryPath, opts?: { parents: boolean }): nil
 
----@class FrecencyPlenaryScanDirOptions
----@field hidden boolean if true hidden files will be added
----@field add_dirs boolean if true dirs will also be added to the results
----@field only_dirs boolean if true only dirs will be added to the results
----@field respect_gitignore boolean if true will only add files that are not ignored by the git
----@field depth integer depth on how deep the search should go
----@field search_pattern string|string[]|fun(path: string): boolean regex for which files will be added, string, table of strings, or fn(e) -> boolean
----@field on_insert fun(path: string): boolean           Will be called for each element
----@field silent boolean              if true will not echo messages that are not accessible
-
----@alias scan_dir fun(path: string, opts: FrecencyPlenaryScanDirOptions): string[]
-
 ---@class FrecencyPlenaryAsync
 ---@field control FrecencyPlenaryAsyncControl
 ---@field tests { add_to_env: fun(): nil }

--- a/lua/frecency/v2/database.lua
+++ b/lua/frecency/v2/database.lua
@@ -3,11 +3,11 @@ local TableV2 = require "frecency.v2.table"
 local config = require "frecency.config"
 local fs = require "frecency.fs"
 local log = require "frecency.log"
+local os_util = require "frecency.os_util"
 local timer = require "frecency.timer"
 local watcher = require "frecency.watcher"
 local lazy_require = require "frecency.lazy_require"
 local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
-local Path = lazy_require "plenary.path" --[[@as FrecencyPlenaryPath]]
 
 -- todo(clason): remove when dropping support for Nvim 0.12
 local npcall = vim.npcall or vim.F.npcall
@@ -33,7 +33,7 @@ end
 ---@async
 ---@return string
 function DatabaseV2:filename()
-  local db = Path.new(config.db_root, "file_frecency_v2.bin").filename
+  local db = os_util.join_path(config.db_root, "file_frecency_v2.bin")
   if not fs.exists(db) then
     local v1 = self:v1_filename()
     if fs.exists(v1) then
@@ -51,9 +51,9 @@ end
 ---@return string
 function DatabaseV2:v1_filename() -- luacheck: no self
   local file_v1 = "file_frecency.bin"
-  local db = Path.new(config.db_root, file_v1).filename
+  local db = os_util.join_path(config.db_root, file_v1)
   if not config.ext_config.db_root and not fs.exists(db) then
-    local old_location = Path.new(vim.fn.stdpath "data", file_v1).filename
+    local old_location = os_util.join_path(vim.fn.stdpath "data", file_v1)
     if fs.exists(old_location) then
       return old_location
     end


### PR DESCRIPTION
## Summary

PR 3 of the [plenary.nvim removal effort](https://github.com/nvim-telescope/telescope-frecency.nvim/issues/340).

Scope is narrowed to **production code only**: replace `plenary.path` call sites with `vim.fs` / `vim.fn` / `vim.uv` equivalents, and vendor the one `plenary.scandir` function we depend on. Tests are left alone because they still `require "plenary.async"` until PR 2 (gated on nvim-telescope/telescope.nvim#3647) lets us drop it — switching the test framework now does not actually remove the plenary dep, so it is deferred to PR 4.

## Changes

- `lua/frecency/os_util.lua` — expose `M.sep`; switch `M.join_path` from `Path:new(...).filename` to `vim.fs.joinpath(...)`, keeping the Windows `\`-normalization step via the existing `normalize_sep`. (The original "do not use `vim.fs.joinpath` on Windows" caveat still holds because `vim.fs.joinpath` always uses `/`; we just apply `normalize_sep` ourselves now.)
- `lua/frecency/file_lock.lua` — `Path.new(self.lock):parent()` → `vim.fs.dirname`; `dir:exists()` → `vim.uv.fs_stat`; `dir:mkdir { parents = true }` → `vim.fn.mkdir(dir, "p")`.
- `lua/frecency/entry_maker.lua` — `Path.path.sep` → `os_util.sep` (3 sites).
- `lua/frecency/picker.lua` — `Path:new(path):make_relative(opts.cwd)` → `vim.fs.relpath(opts.cwd, path) or path`; `Path.path.sep` → `os_util.sep`.
- `lua/frecency/fs.lua` — `Path:new(path):make_relative(M.os_homedir)` → `vim.fs.relpath(M.os_homedir, path) or path`; `Path.path.sep` → `os_util.sep`; vendor `plenary.scandir.__make_gitignore` into `M.make_gitignore` (the only function we used from `plenary.scandir`, replacing `Path:exists()` with `vim.uv.fs_stat` and `Path:iter()` with `io.lines`).
- `lua/frecency/v2/database.lua` — `Path.new(a, b).filename` → `os_util.join_path(a, b)` (3 sites).
- `lua/frecency/types.lua` — drop the now-unused `FrecencyPlenaryScanDirOptions` / `scan_dir` type aliases. `FrecencyPlenaryPath` and the `FrecencyPlenaryAsync*` types stay because tests still reference them.

## Behavior notes

- `vim.fs.relpath(base, target)` returns `nil` when `target` is not under `base`, while `Path:make_relative(base)` returns the original path unchanged in that case. The `or path` fallback restores the plenary behavior. One corner case still differs: when `target == base`, plenary returns `""` while `vim.fs.relpath` returns `"."` — this only matters if the picker is ever asked to render the cwd itself, which is not a real flow for a file picker.
- All async/uv usage is untouched (`async.uv.fs_*`, `vim.uv.os_homedir`, etc.). Only the OO `Path` wrapper and `plenary.scandir` are removed.
- No public API changes.

## Test plan

- [x] `bin/run-tests` green locally on Neovim stable (Apple Silicon macOS).
  - sorter_spec: 3 / database_spec: 1 / file_lock_spec: 11 / frecency_validate_database_spec: 4 / frecency_spec: 14 → **33 passed, 0 failed**.
- [x] `stylua --check` clean on changed lua files.
- [x] `luacheck` clean on changed lua files (0 warnings / 0 errors).
- [x] CI: Linux / macOS / Windows × stable / nightly (this PR).
- [x] CI: luacheck (this PR).
- [x] CI: lua-typecheck-action (this PR).
- [ ] Windows behavior: `os_util.join_path` now goes through `vim.fs.joinpath` + `normalize_sep`. Covered by CI; not manually tested on Windows here.

## Follow-up PRs (tracking #340)

- **PR 2** — Switch `plenary.log` / `plenary.async` `require`s to the telescope-vendored modules. **Gated on nvim-telescope/telescope.nvim#3647 landing** with stable module names.
- **PR 4** — Test framework migration (depends on PR 2): replace `plenary.path` / `plenary.job` in `tests/util.lua` with `vim.fs` / `vim.system`, update spec callers, switch from `plenary.busted` to nvim-treesitter/plentest.nvim, drop remaining `FrecencyPlenary*` types, finish README / `:help` cleanup, and remove plenary from `bin/run-tests`'s `prepare_lib` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)