### PR TITLE
refactor: switch plenary.log and plenary.async requires to neoplen (PR2 of plenary removal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ to a tag): **2.0.0 is a breaking release.**
   `reference_time + last_accessed` to get the most-recent access epoch (single
   value). The `count` field is preserved as an alias for `num_accesses`.
 - The `db_version` config option is removed.
+- Asynchronous I/O now comes from a module vendored inside `telescope.nvim`
+  (`neoplen`), so loading this plugin non-lazily also loads `telescope.nvim` at
+  `VimEnter`. The startup DB warm-up used to be a minimal `frecency` + `plenary`
+  load; it now unavoidably pulls in `telescope.nvim`, so it is deferred to
+  `VimEnter` to keep that load off Neovim's startup path. Keeping
+  `telescope.nvim` fully lazy while loading this plugin eagerly to register
+  startup buffers is no longer possible; set `bootstrap = false` to keep
+  telescope from loading until you open a picker. This will become possible
+  again once `vim.async` lands in Neovim core.
 
 If you want the previous behaviour (v1 algorithm, Neovim 0.10.x support), pin
 to the v1 line:

--- a/doc/telescope-frecency.txt
+++ b/doc/telescope-frecency.txt
@@ -377,10 +377,19 @@ This will be called by |telescope.nvim| for its initialization. You can also
 call this to initialize this plugin separated from |telescope.nvim|'s
 initialization phase.
 
-This is useful when you want to load |telescope.nvim| lazily, but to load
-this plugin non-lazily (recommended way). If you load this plugin lazily,
-opened buffers at the same time in Neovim launching will not be registered
-into DB. Example configuration for |lazy.nvim| is below.
+Loading this plugin non-lazily is the recommended way: it lets the plugin
+register buffers that are opened while Neovim is launching. If you load this
+plugin lazily, those buffers will not be registered into DB. Example
+configuration for |lazy.nvim| is below.
+
+NOTE: Since 2.0.0 the asynchronous I/O is provided by a module vendored inside
+|telescope.nvim| (`neoplen`). Loading this plugin non-lazily therefore also
+loads |telescope.nvim| itself at |VimEnter|. The startup DB warm-up used to be a
+minimal load (this plugin + plenary); it now unavoidably loads |telescope.nvim|,
+so it is deferred to |VimEnter| to keep that load off Neovim's startup path.
+Keeping |telescope.nvim| fully lazy while this plugin registers startup buffers
+is no longer possible; it will become possible again once `vim.async` lands in
+Neovim core.
 >lua
     {
       "nvim-telescope/telescope-frecency.nvim",
@@ -395,7 +404,9 @@ into DB. Example configuration for |lazy.nvim| is below.
 
     {
       "nvim-telescope/telescope.nvim",
-      -- `cmd` opts makes lazy.nvim load telescope.nvim lazily.
+      -- `cmd` opts makes lazy.nvim load telescope.nvim on the `Telescope`
+      -- command. Note that since 2.0.0 telescope.nvim is additionally loaded
+      -- at VimEnter when frecency registers startup buffers (see setup() note).
       cmd = { "Telescope" },
       config = function()
 	local telescope = require "telescope"
@@ -478,9 +489,15 @@ bootstrap ~
 Default: `true`
 Type: `boolean`
 
-If `true` and you set this plugin to be loaded non-lazily, it initializes DB in
-Neovim startup (before |VimEnter|). This initialization logic works
-asynchronously and does not block Neovim's starting process.
+If `true` and you set this plugin to be loaded non-lazily, it initializes DB at
+|VimEnter|. This initialization logic works asynchronously and does not block
+Neovim's starting process.
+
+NOTE: Since 2.0.0 this initialization is deferred to |VimEnter| (it previously
+ran earlier in startup) and, because the DB uses async I/O vendored inside
+|telescope.nvim| (`neoplen`), it also loads |telescope.nvim| at VimEnter. Set
+this to `false` if you want to keep telescope.nvim from loading until you
+actually open a picker.
 
 				      *telescope-frecency-configuration-db_root*
 db_root ~

--- a/lua/frecency/file_lock.lua
+++ b/lua/frecency/file_lock.lua
@@ -1,6 +1,6 @@
 local log = require "frecency.log"
 local lazy_require = require "frecency.lazy_require"
-local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 ---@class FrecencyFileLock
 ---@field base string

--- a/lua/frecency/finder.lua
+++ b/lua/frecency/finder.lua
@@ -5,7 +5,7 @@ local log = require "frecency.log"
 local timer = require "frecency.timer"
 local lazy_require = require "frecency.lazy_require"
 local Sorter = require "frecency.sorter"
-local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 ---@class FrecencyFinder
 ---@field config FrecencyFinderConfig

--- a/lua/frecency/fs.lua
+++ b/lua/frecency/fs.lua
@@ -2,7 +2,7 @@ local config = require "frecency.config"
 local os_util = require "frecency.os_util"
 local log = require "frecency.log"
 local lazy_require = require "frecency.lazy_require"
-local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 ---@class FrecencyFS
 local M = {

--- a/lua/frecency/init.lua
+++ b/lua/frecency/init.lua
@@ -42,6 +42,27 @@ local function async_call(f, ...)
   require("neoplen.async").void(f)(...)
 end
 
+-- Run an async call now, or defer it to |VimEnter| when still in the startup
+-- phase. `neoplen.async` lives inside telescope.nvim, so calling it makes
+-- lazy-loading plugin managers load telescope.nvim. There is no longer any
+-- reason to do that before VimEnter -- the async DB work still finishes well
+-- before the first picker either way -- while doing it mid-startup would drag
+-- telescope's load onto Neovim's startup critical path. So during startup we
+-- defer to VimEnter.
+local function async_call_or_defer(f, ...)
+  if vim.v.vim_did_enter == 1 then
+    async_call(f, ...)
+    return
+  end
+  local args = { ... }
+  vim.api.nvim_create_autocmd("VimEnter", {
+    once = true,
+    callback = function()
+      async_call(f, unpack(args))
+    end,
+  })
+end
+
 local setup_done = false
 
 ---When this func is called, Frecency instance is NOT created but only
@@ -92,7 +113,7 @@ local function setup(ext_config)
       if is_floatwin or (config.ignore_register and config.ignore_register(args.buf)) then
         return
       end
-      async_call(frecency.register, args.buf, vim.api.nvim_buf_get_name(args.buf))
+      async_call_or_defer(frecency.register, args.buf, vim.api.nvim_buf_get_name(args.buf))
     end,
   })
 
@@ -109,10 +130,19 @@ local function setup(ext_config)
   end
 
   if config.bootstrap and vim.v.vim_did_enter == 0 then
-    database = require("frecency.database").create()
-    async_call(function()
-      database:start()
-    end)
+    -- Defer DB bootstrap to VimEnter: creating the DB touches neoplen.async,
+    -- which loads telescope. VimEnter still warms the DB before the first picker
+    -- while keeping that load off Neovim's startup path. See async_call_or_defer
+    -- above.
+    vim.api.nvim_create_autocmd("VimEnter", {
+      once = true,
+      callback = function()
+        async_call(function()
+          database = require("frecency.database").create()
+          database:start()
+        end)
+      end,
+    })
   end
 
   setup_done = true

--- a/lua/frecency/init.lua
+++ b/lua/frecency/init.lua
@@ -39,7 +39,7 @@ local frecency = setmetatable({}, {
 })
 
 local function async_call(f, ...)
-  require("plenary.async").void(f)(...)
+  require("neoplen.async").void(f)(...)
 end
 
 local setup_done = false

--- a/lua/frecency/klass.lua
+++ b/lua/frecency/klass.lua
@@ -6,7 +6,7 @@ local log = require "frecency.log"
 local timer = require "frecency.timer"
 local wait = require "frecency.wait"
 local lazy_require = require "frecency.lazy_require"
-local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 ---@enum FrecencyStatus
 local STATUS = {

--- a/lua/frecency/lazy_require.lua
+++ b/lua/frecency/lazy_require.lua
@@ -1,3 +1,16 @@
+-- Compat: neoplen.async dropped its `uv` submodule in telescope.nvim commit
+-- b9b203f ("feat(plenary): remove unused async") because telescope itself does
+-- not use it. frecency relies on the async-aware libuv wrappers, so until
+-- upstream restores them (asked for in nvim-telescope/telescope.nvim#3647),
+-- re-attach plenary's uv_async to the neoplen.async module table. Runs once
+-- per session as a side effect of loading this module.
+do
+  local ok, async = pcall(require, "neoplen.async")
+  if ok and not async.uv then
+    async.uv = require "plenary.async.uv_async"
+  end
+end
+
 ---@param module string
 return function(module)
   return setmetatable({}, {

--- a/lua/frecency/lazy_require.lua
+++ b/lua/frecency/lazy_require.lua
@@ -1,16 +1,3 @@
--- Compat: neoplen.async dropped its `uv` submodule in telescope.nvim commit
--- b9b203f ("feat(plenary): remove unused async") because telescope itself does
--- not use it. frecency relies on the async-aware libuv wrappers, so until
--- upstream restores them (asked for in nvim-telescope/telescope.nvim#3647),
--- re-attach plenary's uv_async to the neoplen.async module table. Runs once
--- per session as a side effect of loading this module.
-do
-  local ok, async = pcall(require, "neoplen.async")
-  if ok and not async.uv then
-    async.uv = require "plenary.async.uv_async"
-  end
-end
-
 ---@param module string
 return function(module)
   return setmetatable({}, {

--- a/lua/frecency/log.lua
+++ b/lua/frecency/log.lua
@@ -2,19 +2,6 @@ local config = require "frecency.config"
 local lazy_require = require "frecency.lazy_require"
 local log = lazy_require "neoplen.log"
 
--- Compat: neoplen.log dropped plenary.log's "create the outfile parent dir if
--- missing" step when it stopped depending on plenary.path. The default outfile
--- is `stdpath("log")/neoplen.log`, and on a fresh XDG_STATE_HOME (e.g. CI
--- sandboxes or our test runner) that directory does not exist yet, so the
--- first log line throws ENOENT. Ensure the dir exists once at load time.
--- Track restoration upstream in nvim-telescope/telescope.nvim#3647.
-do
-  local log_dir = vim.fn.stdpath "log" --[[@as string]]
-  if vim.fn.isdirectory(log_dir) == 0 then
-    vim.fn.mkdir(log_dir, "p")
-  end
-end
-
 return setmetatable({}, {
   __index = function(_, key)
     return config.debug and vim.schedule_wrap(function(...)

--- a/lua/frecency/log.lua
+++ b/lua/frecency/log.lua
@@ -1,6 +1,19 @@
 local config = require "frecency.config"
 local lazy_require = require "frecency.lazy_require"
-local log = lazy_require "plenary.log"
+local log = lazy_require "neoplen.log"
+
+-- Compat: neoplen.log dropped plenary.log's "create the outfile parent dir if
+-- missing" step when it stopped depending on plenary.path. The default outfile
+-- is `stdpath("log")/neoplen.log`, and on a fresh XDG_STATE_HOME (e.g. CI
+-- sandboxes or our test runner) that directory does not exist yet, so the
+-- first log line throws ENOENT. Ensure the dir exists once at load time.
+-- Track restoration upstream in nvim-telescope/telescope.nvim#3647.
+do
+  local log_dir = vim.fn.stdpath "log" --[[@as string]]
+  if vim.fn.isdirectory(log_dir) == 0 then
+    vim.fn.mkdir(log_dir, "p")
+  end
+end
 
 return setmetatable({}, {
   __index = function(_, key)

--- a/lua/frecency/tests/database_spec.lua
+++ b/lua/frecency/tests/database_spec.lua
@@ -1,8 +1,8 @@
 local Database = require "frecency.database"
 local config = require "frecency.config"
-local async = require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 local util = require "frecency.tests.util"
-async.tests.add_to_env()
+util.add_async_to_env()
 
 local function with_database(f)
   local dir, close = util.tmpdir()

--- a/lua/frecency/tests/file_lock_spec.lua
+++ b/lua/frecency/tests/file_lock_spec.lua
@@ -2,8 +2,8 @@
 local config = require "frecency.config"
 local FileLock = require "frecency.file_lock"
 local util = require "frecency.tests.util"
-local async = require "plenary.async" --[[@as FrecencyPlenaryAsync]]
-require("plenary.async").tests.add_to_env()
+local async = require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
+util.add_async_to_env()
 
 config.setup { debug = true }
 

--- a/lua/frecency/tests/frecency_validate_database_spec.lua
+++ b/lua/frecency/tests/frecency_validate_database_spec.lua
@@ -1,5 +1,5 @@
 local util = require "frecency.tests.util"
-local async = require "plenary.async"
+local async = require "neoplen.async"
 
 local filepath = util.filepath
 local make_epoch = util.make_epoch

--- a/lua/frecency/tests/util.lua
+++ b/lua/frecency/tests/util.lua
@@ -1,9 +1,10 @@
 ---@diagnostic disable: invisible, undefined-field
+-- luacheck: globals describe it pending before_each after_each
 local Frecency = require "frecency.klass"
 local Picker = require "frecency.picker"
 local config = require "frecency.config"
-local log = require "plenary.log"
-local async = require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local log = require "neoplen.log"
+local async = require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 local Path = require "plenary.path"
 local Job = require "plenary.job"
 local wait = require "frecency.wait"
@@ -199,7 +200,32 @@ local function with_fake_vim_ui_select(choice, callback)
   vim.ui.select = original_vim_ui_select
 end
 
+-- Replacement for `require("plenary.async").tests.add_to_env()` — neoplen
+-- removed the `async.tests` submodule, so we inline the minimal helpers that
+-- frecency's spec files use (`a.describe` / `a.it` / `a.before_each` /
+-- `a.after_each` / `a.pending`). Sets `_G.a` so call sites resolve through the
+-- global table the same way `setfenv`-based add_to_env did.
+local function add_async_to_env()
+  local timeout = tonumber(vim.env.PLENARY_TEST_TIMEOUT)
+  _G.a = {
+    describe = describe,
+    it = function(s, async_func)
+      it(s, async.util.will_block(async_func, timeout))
+    end,
+    pending = function(async_func)
+      pending(async_func)
+    end,
+    before_each = function(async_func)
+      before_each(async.util.will_block(async_func))
+    end,
+    after_each = function(async_func)
+      after_each(async.util.will_block(async_func))
+    end,
+  }
+end
+
 return {
+  add_async_to_env = add_async_to_env,
   filepath = filepath,
   make_epoch = make_epoch,
   make_register = make_register,

--- a/lua/frecency/v2/database.lua
+++ b/lua/frecency/v2/database.lua
@@ -7,7 +7,7 @@ local os_util = require "frecency.os_util"
 local timer = require "frecency.timer"
 local watcher = require "frecency.watcher"
 local lazy_require = require "frecency.lazy_require"
-local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 -- todo(clason): remove when dropping support for Nvim 0.12
 local npcall = vim.npcall or vim.F.npcall

--- a/lua/frecency/v2/table.lua
+++ b/lua/frecency/v2/table.lua
@@ -3,7 +3,7 @@ local log = require "frecency.log"
 local timer = require "frecency.timer"
 local wait = require "frecency.wait"
 local lazy_require = require "frecency.lazy_require"
-local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 -- v1 record / data shape kept here because TableV2:from_v1 still consumes
 -- them for the v1 → v2 migration in 2.0.0.

--- a/lua/frecency/wait.lua
+++ b/lua/frecency/wait.lua
@@ -1,4 +1,4 @@
-local async = require "plenary.async"
+local async = require "neoplen.async"
 
 ---@class FrecencyWait
 ---@field config FrecencyWaitConfig

--- a/lua/frecency/wait.lua
+++ b/lua/frecency/wait.lua
@@ -1,4 +1,5 @@
-local async = require "neoplen.async"
+local lazy_require = require "frecency.lazy_require"
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 ---@class FrecencyWait
 ---@field config FrecencyWaitConfig

--- a/lua/frecency/watcher.lua
+++ b/lua/frecency/watcher.lua
@@ -1,6 +1,6 @@
 local log = require "frecency.log"
 local lazy_require = require "frecency.lazy_require"
-local async = lazy_require "plenary.async" --[[@as FrecencyPlenaryAsync]]
+local async = lazy_require "neoplen.async" --[[@as FrecencyPlenaryAsync]]
 
 ---@class FrecencyWatcherMtime
 ---@field sec integer


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft, blocked on [nvim-telescope/telescope.nvim#3647](https://github.com/nvim-telescope/telescope.nvim/pull/3647).**
> The `neoplen.*` modules this PR `require`s ship only on telescope's `feat/neoplen` branch. CI on this PR will fail because the test runner clones telescope's `master` (which does not have those modules). Verified locally against `feat/neoplen` instead — see "Verification" below.
>
> The `neoplen` namespace itself is explicitly temporary per [clason in the upstream PR body](https://github.com/nvim-telescope/telescope.nvim/pull/3647#issue). This branch will need a final rename (mechanical `sed`) once upstream settles on the final module names.

## Summary

PR 2 of the [plenary.nvim removal effort](https://github.com/nvim-telescope/telescope-frecency.nvim/issues/340). Renames every `require "plenary.log"` / `require "plenary.async"` (and `lazy_require` / inline `require("...")` variants) in production code and tests to the telescope-vendored equivalent. No call-site rewrites — just the module name on the `require` line.

## Upstream gaps surfaced while migrating

Three gaps vs `plenary.*` were uncovered. Gaps 1 and 2 have since been fixed on `feat/neoplen`, so the inline workarounds added earlier in this draft have been **removed** (commit "drop neoplen.async.uv / neoplen.log compat shims"). Gap 3 is a permanent reimplementation that stays.

### 1. `neoplen.async` no longer had the `uv` submodule — ✅ resolved upstream

Removed in telescope commit `b9b203f` ("feat(plenary): remove unused async"). frecency calls `async.uv.fs_{stat,open,close,read,write,unlink,realpath}` from 17 production sites (file_lock, fs, klass, watcher, v2/database) and 6 test sites — the async-aware libuv wrappers are core to how we do non-blocking I/O.

**Resolution**: restored upstream via [nvim-telescope/telescope.nvim#3669](https://github.com/nvim-telescope/telescope.nvim/pull/3669) (cherry-picked into `feat/neoplen` on 2026-05-22). `lua/neoplen/async/uv_async.lua` now exports exactly those seven `fs_*` wrappers, and `neoplen/async/init.lua` resolves `neoplen.async.uv` through its `__index` lookups. The `plenary.async.uv_async` re-attach block in `lua/frecency/lazy_require.lua` is therefore deleted — this also removes the last production-code reference to `plenary` in this PR.

### 2. `neoplen.log` did not create the outfile parent directory — ✅ resolved upstream

`plenary.log` did `Path:new(outfile):parent():mkdir { parents = true }` at `log.new()` time; `neoplen.log` had dropped that step when it shed `plenary.path`. On a fresh `XDG_STATE_HOME` (e.g. our test sandbox), `stdpath("log")` does not exist, and the first log line threw ENOENT on `io.open(outfile, "a")`.

**Resolution**: `feat/neoplen`'s `log.new()` now `vim.fn.mkdir(stdpath("log"), "p")`s the log dir itself. The load-time `mkdir` block in `lua/frecency/log.lua` is therefore deleted.

### 3. `neoplen.async.tests.add_to_env()` is gone — reimplemented in-tree (stays)

Removed in commit `18572e9` ("feat(plenary): remove unused async.tests"). frecency's `database_spec` and `file_lock_spec` used it to inject `a.describe / a.it / a.before_each / a.after_each / a.pending`.

**Replacement in this PR**: small inline `util.add_async_to_env()` helper in `lua/frecency/tests/util.lua` — sets `_G.a` with five functions wrapping `neoplen.async.util.will_block`. Same primitive plenary's `add_to_env` used. Not a workaround, just an inline reimplementation — kept regardless of what upstream decides (`async.tests` is gone for good).

## Changes

- **Rename**: `plenary.async` → `neoplen.async` and `plenary.log` → `neoplen.log` across 14 files (production + tests).
- **`lua/frecency/tests/util.lua`**: add `add_async_to_env()` helper and export it (replacement for gap 3). Add a `-- luacheck: globals describe it ...` pragma because util.lua is not a `*_spec.lua` file and so doesn't auto-pick up busted globals.
- **`lua/frecency/tests/{database,file_lock}_spec.lua`**: replace `async.tests.add_to_env()` calls with `util.add_async_to_env()`.

The gap 1 / gap 2 workaround blocks that earlier commits added to `lazy_require.lua` and `log.lua` have been removed now that `feat/neoplen` covers both; `lazy_require.lua` is back to identical with `master` and `log.lua`'s only diff vs `master` is the one-line `require "neoplen.log"`.

`FrecencyPlenaryAsync*` and `FrecencyPlenaryLog` type aliases are intentionally **not** renamed — keeping them minimises diff noise until the upstream name finalises; they'll be renamed in the same `sed` that flips `neoplen` to its final name.

## Startup load-order change (behavior change in this PR)

`neoplen.*` lives **inside** telescope.nvim, so a lazy-loading plugin manager loads telescope.nvim when frecency requires `neoplen.async`. frecency's `setup()` does async I/O during startup — the `bootstrap` DB warm-up and the `BufWinEnter`/`BufWritePost` register autocmd for command-line-opened files. Pre-neoplen this was cheap, telescope-free work (frecency + plenary only), so doing it during startup to warm the DB before the first `:Telescope frecency` made sense. Post-neoplen it **unavoidably loads telescope**, so there is no longer any reason to run it before `VimEnter`: the async DB warm-up still finishes well before the first picker, while running it mid-startup would drag telescope's load onto Neovim's startup critical path.

Fix:

- **`wait.lua`**: require `neoplen.async` via `lazy_require` like every other module, so merely requiring the DB modules no longer loads telescope.
- **`init.lua`**: add `async_call_or_defer()` — runs immediately once `vim_did_enter == 1`, else defers to a one-shot `VimEnter` autocmd. Used for the register autocmd; the `bootstrap` block is likewise deferred to `VimEnter`. So during startup frecency touches telescope only at `VimEnter` (off the startup path, still before the first picker).
- **Docs**: this is a **2.0 behavior change** — eager frecency loads telescope at `VimEnter`, so telescope can no longer stay fully lazy while frecency eager-loads to register startup buffers (returns once `vim.async` lets frecency drop the `neoplen.async` dependency). Documented in `README` "Upgrading to 2.0.0" and the `:help` `setup()` / `bootstrap` sections.

## Verification

Run against a `feat/neoplen` clone (with the #3669 cherry-pick), `~/.cache/telescope-frecency/info.json` pointing `nvim-telescope/telescope.nvim` at it:

Full suite passes against `feat/neoplen`: **sorter 3 / database 1 / file_lock 11 / frecency_validate_database 4 / frecency 14 → 33 passed, 0 failed** (on a current Neovim nightly; an earlier nightly had an unrelated empty-picker-result issue in the register flow that also reproduced on plain `master`, and is gone now).
- stylua + luacheck clean on the changed `.lua` files.

**Reproduction recipe**:

```sh
git clone --branch feat/neoplen --depth 1 https://github.com/nvim-telescope/telescope.nvim /tmp/telescope-neoplen
# Edit ~/.cache/telescope-frecency/info.json so nvim-telescope/telescope.nvim.path points at /tmp/telescope-neoplen
bin/run-tests
```

CI on this PR is expected to fail at the require-resolution step until telescope#3647 lands.

## Follow-up

- **Rebase after telescope#3647 merges**: mechanical sed of `neoplen` → final name (including the `FrecencyPlenary*` type aliases).
- **PR 4**: test framework migration (path/job in tests, busted → plentest.nvim). Now genuinely possible because production no longer needs plenary at all (only `tests/util.lua` still does, via `plenary.path` + `plenary.job`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


